### PR TITLE
Cashew-inspired visual UI rework

### DIFF
--- a/docs/plans/2026-04-29-cashew-inspired-ui-font-plan.md
+++ b/docs/plans/2026-04-29-cashew-inspired-ui-font-plan.md
@@ -7,6 +7,29 @@
 
 ---
 
+## 0. Current Status and Correction
+
+**Status as of PR #3:** A first follow-up pass was implemented and merged, but it was too conservative.
+
+Completed in PR #3:
+
+- Added this Cashew-inspired planning document.
+- Added Manrope display typography for headings and large financial values.
+- Added local-only accent color and density preferences under Settings.
+- Added transaction account/category filters and quick-action type defaults.
+- Added basic report chart panels and derived insight copy.
+- Added dashboard section visibility preferences stored in `localStorage`.
+
+Important correction:
+
+> PR #3 does **not** yet make Ledgerify visually feel like Cashew.
+
+The work shipped in PR #3 is technically valid and keeps the no-schema-change boundary, but it mostly adds infrastructure and mild polish. It does not sufficiently adopt Cashew’s visible UI language: Material You tonal cards, mobile-first transaction composition, expressive widgets, richer category/account visuals, or graph-forward home surfaces.
+
+The next implementation should be treated as **Cashew Visual Rework v2**, not as a continuation of small polish.
+
+---
+
 ## 1. Why Cashew Is a Useful Reference
 
 Cashew is a strong inspiration because it makes a finance app feel personal and adaptable instead of rigid. Its README highlights the qualities most relevant to Ledgerify:
@@ -21,6 +44,23 @@ Cashew is a strong inspiration because it makes a finance app feel personal and 
 - Flexible budgets, accounts, currencies, and goals.
 
 Ledgerify should not copy Cashew directly. Ledgerify should keep the **Quiet Ledger** positioning: private, family-friendly, calm, web-first, and trustworthy. Cashew should influence the next layer of polish: softer personalization, more expressive financial state, better typography, richer mobile ergonomics, and more useful chart surfaces.
+
+### 1.1 Concrete Cashew Code Findings
+
+The next pass should be grounded in the actual Cashew app structure, not only its README or screenshots. Relevant reference points from the local Cashew checkout:
+
+- `budget/lib/colors.dart`: Cashew builds a Material 3 `ColorScheme` from a user accent seed, then derives light/dark backgrounds, navigation colors, splash colors, and local theme extensions from that seed.
+- `budget/lib/pages/homePage/homePage.dart`: the home page is assembled from named widgets such as wallet switcher, wallet list, budgets, upcoming transactions, spending summary, net worth, objectives, credit/debts, line graph, pie chart, heatmap, and transactions.
+- `budget/lib/pages/editHomePage.dart`: the home screen is not a fixed report; it has a real edit surface with enable/disable controls and per-widget settings.
+- `budget/lib/widgets/transactionEntry/transactionEntry.dart`: transaction rows are visually led by category icon, transaction/category labels, tags, note indicator, transaction type affordance, and amount hierarchy.
+- `budget/lib/widgets/categoryIcon.dart`: categories have dedicated colored icon containers, optional tinting, tooltip support, labels, and long-press edit affordances.
+- `budget/lib/widgets/budgetContainer.dart`: budgets are treated as expressive containers with colored backgrounds, animated values, timeline context, and progress bars.
+- `budget/lib/widgets/slidingSelectorIncomeExpense.dart` and `budget/lib/widgets/selectChips.dart`: filtering uses tactile segmented controls and chips, not plain select controls.
+- `budget/lib/widgets/transactionsAmountBox.dart`: summary totals are compact tappable boxes with amount, label, and transaction count.
+- `budget/lib/widgets/fab.dart` and `budget/lib/widgets/bottomNavBar.dart`: mobile primary action and navigation are first-class surfaces with custom sizes, tonal colors, and long-press/shortcut behavior.
+- `budget/lib/widgets/importCSV.dart`: import is a guided mapping flow with progress and explicit required fields.
+
+Translate these ideas into Ledgerify components. Do not copy Flutter code, names, animations, or implementation details directly.
 
 ---
 
@@ -60,6 +100,28 @@ Do not borrow:
 - Excessive customization before core workflows are stable.
 - Dense feature sprawl.
 - Any schema-heavy concepts that would require backend changes.
+
+### 2.3 Cashew Visual Rework v2 Direction
+
+The next pass must be visibly different at first glance. It should focus on concrete UI composition, not preferences infrastructure.
+
+Primary visual moves:
+
+- Replace generic metric-card grids with larger, colorful, widget-like financial tiles.
+- Use Material You-style tonal containers for each domain:
+  - Cash/accounts: sky tonal surface.
+  - Spending: rose tonal surface.
+  - Budgets: amber/teal tonal surface.
+  - Goals: teal tonal surface.
+  - Investments: emerald/violet tonal surface.
+  - Loans: rose/orange tonal surface.
+  - Insurance: indigo tonal surface.
+- Add stronger icon-led cards with more useful subtitles and progress states.
+- Make dashboard feel like a configurable mobile finance home, not a desktop report page.
+- Make transaction entry and review feel like the center of the app.
+- Make reports chart-first and visually richer.
+
+This v2 pass should modify visible page composition before adding more settings or preferences.
 
 ---
 
@@ -196,6 +258,47 @@ Dashboard should include:
 
 Each section should answer one question.
 
+### 5.3 Cashew Visual Dashboard Rework
+
+Replace the current conservative dashboard with a widget-style composition:
+
+1. **Balance Snapshot Widget**
+   - Large net worth number.
+   - Small asset/liability split chips.
+   - Tonal background using the active accent.
+   - Quick links to net worth, accounts, investments, and loans.
+
+2. **Daily Money Widget**
+   - This month income, expenses, and net.
+   - Use a compact visual bar/ring.
+   - Show one plain-language status:
+     - “Spending is below income this month.”
+     - “Expenses are ahead this month.”
+
+3. **Quick Add Strip**
+   - Prominent actions:
+     - Expense
+     - Income
+     - Transfer
+   - Designed as pill/tile buttons with meaningful colors.
+
+4. **Planning Widgets**
+   - Budget health tile.
+   - Goal progress tile.
+   - Use progress rings/bars and status text.
+
+5. **Protection and Debt Widgets**
+   - Next EMI.
+   - Next insurance renewal.
+   - Show due dates as calm countdowns.
+
+6. **Recent Activity**
+   - Denser Cashew-like transaction rows.
+   - Category/account context visible.
+   - Destructive actions hidden behind overflow.
+
+No schema changes required. Use currently available server data.
+
 ---
 
 ## 6. Transaction UX Follow-Up Plan
@@ -233,6 +336,44 @@ Improve transaction rows:
   - Income
   - Transfer
 - This can be done via query params and form defaults, no schema changes.
+
+### 6.4 Cashew Visual Transaction Rework
+
+The next transaction pass should go beyond filters:
+
+- Add a top summary strip:
+  - Income this month.
+  - Expenses this month.
+  - Net this month.
+- Convert type chips into Material-style segmented controls.
+- Add category/account filter chips with active color.
+- Replace visible delete icon with an overflow menu or secondary inline action.
+- Show transaction category/account metadata as the primary scanning line.
+- Use compact rows on mobile with:
+  - Category icon/tone.
+  - Note/category.
+  - Account/date.
+  - Amount.
+- Add a proper empty state with three action tiles:
+  - Add expense.
+  - Add income.
+  - Import CSV.
+
+### 6.5 Cashew-Specific Transaction Targets
+
+Ledgerify should visibly adopt these transaction patterns:
+
+- A reusable category/account glyph component with a colored tonal square or circle, not just text labels.
+- Amount boxes above the list that include label, amount, and count, similar in purpose to Cashew's `TransactionsAmountBox`.
+- A segmented income/expense/all control with a filled active indicator.
+- Horizontal chips for account/category filtering with active tint and optional glyphs.
+- Row layout order:
+  - category glyph
+  - title or category name
+  - account/date/note context
+  - tags or status chips
+  - signed amount
+- Mobile entry actions should be reachable from a prominent FAB or equivalent bottom action, with long-press or secondary sheet reserved for advanced add flows.
 
 ---
 
@@ -298,6 +439,19 @@ Improve utility pages:
 - Import should preview required columns.
 - Add CSV template field list.
 - Keep errors calm and readable.
+
+### 8.3 Cashew-Inspired Import Polish
+
+Use Cashew's import flow as a UX reference for Ledgerify's existing CSV import, without changing backend behavior:
+
+- Present import as a short guided flow:
+  - choose file
+  - review required columns
+  - map/confirm columns
+  - preview import result
+- Make required fields visually explicit.
+- Show a compact progress indicator when parsing.
+- Keep sample/template CSV access close to the error and empty states.
 
 ---
 
@@ -385,6 +539,36 @@ Validation:
 - Preferences persist locally.
 - Dashboard remains useful on first run.
 
+### Milestone 6: Cashew Visual Rework v2
+
+Goal: make the visible app feel meaningfully Cashew-inspired while preserving Ledgerify's Quiet Ledger identity.
+
+Tasks:
+
+- Replace plain dashboard metric grids with colorful financial widgets for balance, monthly movement, budgets, goals, obligations, and recent activity.
+- Build shared visual primitives:
+  - tonal finance widget
+  - category/account glyph
+  - amount summary box
+  - segmented transaction selector
+  - chip rail
+  - progress/timeline bar
+- Rework budgets and goals into expressive progress surfaces with clear remaining/spent/saved values.
+- Rework accounts, loans, insurance, and investments into domain-colored summary widgets.
+- Rework reports around chart-first cards and stronger empty states.
+- Rework import/export surfaces into guided utility flows.
+
+Validation:
+
+- `/dashboard`, `/transactions`, `/budgets`, `/goals`, `/reports`, `/accounts`, `/loans`, `/insurance`, and `/settings` should all be visibly upgraded.
+- Desktop and mobile screenshots should show Cashew-like widget composition, not only typography and settings changes.
+- No schema changes.
+- No backend/domain logic changes.
+- Existing validation commands must pass:
+  - `bunx tsc --noEmit`
+  - `bun run lint`
+  - `bun run build`
+
 ---
 
 ## 10. Concrete Design Decisions
@@ -445,6 +629,8 @@ Do not include in this plan:
 - Full widget customization stored in database.
 - Cashew feature parity.
 
+Also do not substitute preferences for visible product work. Accent settings, density settings, and dashboard visibility toggles are useful, but they do not satisfy the Cashew-inspired UI goal by themselves.
+
 ---
 
 ## 12. Success Criteria
@@ -459,3 +645,37 @@ The follow-up succeeds if:
 - Daily transaction review becomes faster.
 - No schema or backend/domain behavior changes are required.
 
+## 13. Next PR Scope: Cashew Visual Rework v2
+
+The next implementation PR should be a UI-only rework on top of latest `main`.
+
+Recommended segments, committed and pushed separately:
+
+1. **Dashboard Widgets**
+   - Add shared tonal widget primitives.
+   - Rebuild the dashboard as a Cashew-style money home.
+   - Keep all data derived from existing loaders/actions.
+
+2. **Transactions**
+   - Add category/account glyphs, amount summary boxes, segmented controls, chip rails, and denser rows.
+   - Keep existing create/update/delete behavior unchanged.
+
+3. **Budgets and Goals**
+   - Rework list/detail cards into progress-first surfaces.
+   - Add timeline/remaining/spent visual treatment using existing fields only.
+
+4. **Accounts, Wealth, and Obligations**
+   - Rework accounts, investments, loans, and insurance into domain-colored widgets.
+   - Improve setup/empty states without new data requirements.
+
+5. **Reports and Import**
+   - Make reports chart-first.
+   - Turn import/export into clearer guided flows.
+
+Acceptance criteria:
+
+- The UI should be visibly different from PR #3 at first glance.
+- Cashew-inspired elements must appear in app surfaces, not only settings.
+- No database schema migration.
+- No backend/domain logic change.
+- Validation must pass with Bun.

--- a/src/app/(app)/budgets/goals/page.tsx
+++ b/src/app/(app)/budgets/goals/page.tsx
@@ -14,9 +14,8 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import {
+  AmountBox,
   EmptyState,
-  FinancialAmount,
-  MetricCard,
   PageHeader,
   PageShell,
   SectionHeader,
@@ -81,27 +80,42 @@ export default async function SavingsGoalsPage() {
       </PageHeader>
 
       <div className="grid gap-4 md:grid-cols-3">
-        <MetricCard
+        <AmountBox
           label="Saved"
-          value={<FinancialAmount amount={totalSaved} currency={baseCurrency} sign="never" />}
-          description="Total progress recorded across all goals."
+          amount={totalSaved}
+          currency={baseCurrency}
           icon={PiggyBank}
-          tone={totalSaved > 0 ? 'positive' : 'neutral'}
+          tone={totalSaved > 0 ? 'goal' : 'neutral'}
+          count="Total progress across goals"
         />
-        <MetricCard
+        <AmountBox
           label="Targets"
-          value={<FinancialAmount amount={totalTarget} currency={baseCurrency} sign="never" />}
-          description="Money assigned to future plans."
+          amount={totalTarget}
+          currency={baseCurrency}
           icon={Target}
           tone={goalList.length > 0 ? 'primary' : 'neutral'}
+          count="Money assigned to future plans"
         />
-        <MetricCard
-          label="Next milestone"
-          value={nextDeadline?.deadline ? new Date(nextDeadline.deadline).toLocaleDateString() : 'None'}
-          description={nextDeadline ? nextDeadline.name : 'Add a deadline to make progress easier to pace.'}
-          icon={Flag}
-          tone={nextDeadline ? 'info' : 'neutral'}
-        />
+        <div className="rounded-3xl border bg-background/70 p-4 shadow-sm shadow-foreground/5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                Next milestone
+              </p>
+              <p className="mt-2 truncate text-xl font-bold text-sky-800 dark:text-sky-200">
+                {nextDeadline?.deadline
+                  ? new Date(nextDeadline.deadline).toLocaleDateString()
+                  : 'None'}
+              </p>
+            </div>
+            <Flag className="mt-1 size-5 shrink-0 text-sky-700 dark:text-sky-300" />
+          </div>
+          <p className="mt-3 text-xs leading-5 text-muted-foreground">
+            {nextDeadline
+              ? nextDeadline.name
+              : 'Add a deadline to make progress easier to pace'}
+          </p>
+        </div>
       </div>
 
       {goalList.length === 0 ? (

--- a/src/app/(app)/budgets/page.tsx
+++ b/src/app/(app)/budgets/page.tsx
@@ -15,10 +15,9 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet'
 import {
+  AmountBox,
   EmptyState,
-  FinancialAmount,
   HeaderActionLink,
-  MetricCard,
   PageHeader,
   PageShell,
   SectionHeader,
@@ -126,26 +125,29 @@ export default async function BudgetsPage() {
       </PageHeader>
 
       <div className="grid gap-4 md:grid-cols-3">
-        <MetricCard
+        <AmountBox
           label="Planned"
-          value={<FinancialAmount amount={totalPlanned} currency={baseCurrency} sign="never" />}
-          description="Total active budget boundaries for this period."
+          amount={totalPlanned}
+          currency={baseCurrency}
           icon={Gauge}
-          tone={budgetList.length > 0 ? 'info' : 'neutral'}
+          tone={budgetList.length > 0 ? 'budget' : 'neutral'}
+          count="Total active budget boundaries"
         />
-        <MetricCard
+        <AmountBox
           label="Spent"
-          value={<FinancialAmount amount={totalSpent} currency={baseCurrency} sign="never" />}
-          description="Expenses matched to weekly and monthly budget windows."
+          amount={totalSpent}
+          currency={baseCurrency}
           icon={TrendingDown}
           tone={totalSpent > totalPlanned && totalPlanned > 0 ? 'negative' : 'positive'}
+          count="Expenses in weekly and monthly windows"
         />
-        <MetricCard
+        <AmountBox
           label={remaining >= 0 ? 'Still available' : 'Over planned'}
-          value={<FinancialAmount amount={Math.abs(remaining)} currency={baseCurrency} sign="never" />}
-          description={`${atRiskCount} budget${atRiskCount === 1 ? '' : 's'} need attention.`}
+          amount={Math.abs(remaining)}
+          currency={baseCurrency}
           icon={WalletCards}
           tone={remaining < 0 ? 'negative' : atRiskCount > 0 ? 'warning' : 'positive'}
+          count={`${atRiskCount} budget${atRiskCount === 1 ? '' : 's'} need attention`}
         />
       </div>
 

--- a/src/app/(app)/import/page.tsx
+++ b/src/app/(app)/import/page.tsx
@@ -5,10 +5,10 @@ import { generateTemplateCSV } from '@/lib/utils/csv'
 import { Download, FileSpreadsheet, ShieldCheck, Upload } from 'lucide-react'
 import {
   IconBadge,
-  MetricCard,
   PageHeader,
   PageShell,
   SectionHeader,
+  TonalWidget,
 } from '@/components/shared/quiet-ledger'
 
 interface ImportResult { imported: number; errors: string[]; total: number }
@@ -70,10 +70,10 @@ export default function ImportPage() {
           />
 
           <div className="grid gap-4 md:grid-cols-2">
-            <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+            <TonalWidget tone="info" className="p-5 sm:p-5">
               <IconBadge icon={Download} tone="info" />
               <div className="mt-4 space-y-2">
-                <h2 className="text-base font-semibold tracking-tight">
+                <h2 className="text-base font-semibold">
                   Download template
                 </h2>
                 <p className="text-sm leading-6 text-muted-foreground">
@@ -84,12 +84,12 @@ export default function ImportPage() {
                   Download template
                 </Button>
               </div>
-            </div>
+            </TonalWidget>
 
-            <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+            <TonalWidget tone="primary" className="p-5 sm:p-5">
               <IconBadge icon={Upload} tone="primary" />
               <div className="mt-4 space-y-2">
-                <h2 className="text-base font-semibold tracking-tight">Upload CSV</h2>
+                <h2 className="text-base font-semibold">Upload CSV</h2>
                 <form onSubmit={handleUpload} className="space-y-3">
                   <input
                     ref={fileRef}
@@ -104,25 +104,31 @@ export default function ImportPage() {
                   </Button>
                 </form>
               </div>
-            </div>
+            </TonalWidget>
           </div>
         </div>
 
         <aside className="space-y-4">
-          <MetricCard
-            label="Format"
-            value="CSV"
-            description="Best for bank exports and spreadsheet cleanup."
-            icon={FileSpreadsheet}
-            tone="info"
-          />
-          <MetricCard
-            label="Safety"
-            value="Review"
-            description="Import reports row errors instead of silently hiding them."
-            icon={ShieldCheck}
-            tone="positive"
-          />
+          <TonalWidget tone="info" className="p-5 sm:p-5">
+            <IconBadge icon={FileSpreadsheet} tone="info" />
+            <p className="mt-4 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Format
+            </p>
+            <h2 className="mt-2 text-2xl font-bold">CSV</h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Best for bank exports and spreadsheet cleanup.
+            </p>
+          </TonalWidget>
+          <TonalWidget tone="positive" className="p-5 sm:p-5">
+            <IconBadge icon={ShieldCheck} tone="positive" />
+            <p className="mt-4 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Safety
+            </p>
+            <h2 className="mt-2 text-2xl font-bold">Review</h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Import reports row errors instead of silently hiding them.
+            </p>
+          </TonalWidget>
         </aside>
       </div>
 

--- a/src/app/(app)/networth/page.tsx
+++ b/src/app/(app)/networth/page.tsx
@@ -4,12 +4,13 @@ import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { computeNetworth } from '@/lib/utils/networth'
 import {
+  AmountBox,
   FinancialAmount,
-  MetricCard,
   PageHeader,
   PageShell,
   ProgressMeter,
   SectionHeader,
+  TonalWidget,
 } from '@/components/shared/quiet-ledger'
 import { Landmark, Scale, TrendingUp, WalletCards } from 'lucide-react'
 
@@ -37,11 +38,11 @@ export default async function NetworthPage() {
         </div>
       </PageHeader>
 
-      <div className="rounded-3xl border bg-card/85 p-6 shadow-sm shadow-foreground/5 sm:p-8">
+      <TonalWidget tone="primary" className="p-6 sm:p-8">
         <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
           Total net worth
         </p>
-        <p className="financial-display mt-2 text-4xl font-bold tracking-tight sm:text-6xl">
+        <p className="financial-display mt-2 text-4xl font-bold sm:text-6xl">
           <FinancialAmount amount={networth} currency={baseCurrency} sign="never" />
         </p>
         <div className="mt-6 max-w-xl">
@@ -52,29 +53,32 @@ export default async function NetworthPage() {
             label="Owned after liabilities"
           />
         </div>
-      </div>
+      </TonalWidget>
 
       <div className="grid gap-4 md:grid-cols-3">
-        <MetricCard
+        <AmountBox
           label="Cash and accounts"
-          value={<FinancialAmount amount={totalCash} currency={baseCurrency} sign="never" />}
-          description="Accessible money containers included in the snapshot."
+          amount={totalCash}
+          currency={baseCurrency}
           icon={WalletCards}
-          tone="info"
+          tone="cash"
+          count="Accessible money containers"
         />
-        <MetricCard
+        <AmountBox
           label="Investments"
-          value={<FinancialAmount amount={totalInvestments} currency={baseCurrency} sign="never" />}
-          description="Longer-term assets counted toward household wealth."
+          amount={totalInvestments}
+          currency={baseCurrency}
           icon={TrendingUp}
-          tone="positive"
+          tone="investment"
+          count="Longer-term household assets"
         />
-        <MetricCard
+        <AmountBox
           label="Liabilities"
-          value={<FinancialAmount amount={totalLiabilities} currency={baseCurrency} sign="never" />}
-          description={`${liabilityRatio.toFixed(0)}% of tracked assets.`}
+          amount={totalLiabilities}
+          currency={baseCurrency}
           icon={Landmark}
-          tone={totalLiabilities > 0 ? 'negative' : 'neutral'}
+          tone={totalLiabilities > 0 ? 'loan' : 'neutral'}
+          count={`${liabilityRatio.toFixed(0)}% of tracked assets`}
         />
       </div>
 

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -6,6 +6,7 @@ import {
   PageShell,
   QuickActionCard,
   SectionHeader,
+  TonalWidget,
 } from '@/components/shared/quiet-ledger'
 
 const reports = [
@@ -32,17 +33,19 @@ export default function ReportsPage() {
         />
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         {reports.map(r => (
-          <Link
+          <TonalWidget
             key={r.href}
-            href={r.href}
-            className="group rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5 transition hover:-translate-y-0.5 hover:bg-card hover:shadow-md"
+            tone="primary"
+            className="group p-5 transition hover:-translate-y-0.5 hover:bg-card hover:shadow-md sm:p-5"
           >
-            <IconBadge icon={r.icon} tone="primary" />
-            <div className="mt-4 space-y-2">
-              <h2 className="text-base font-semibold tracking-tight">{r.title}</h2>
-              <p className="text-sm leading-6 text-muted-foreground">{r.description}</p>
-            </div>
-          </Link>
+            <Link href={r.href} className="block">
+              <IconBadge icon={r.icon} tone="primary" />
+              <div className="mt-4 space-y-2">
+                <h2 className="text-base font-semibold">{r.title}</h2>
+                <p className="text-sm leading-6 text-muted-foreground">{r.description}</p>
+              </div>
+            </Link>
+          </TonalWidget>
         ))}
         </div>
       </section>

--- a/src/app/(app)/settings/data/page.tsx
+++ b/src/app/(app)/settings/data/page.tsx
@@ -1,6 +1,6 @@
 import { DatabaseBackup, Download, ShieldAlert } from 'lucide-react'
 
-import { IconBadge, SectionHeader } from '@/components/shared/quiet-ledger'
+import { IconBadge, SectionHeader, TonalWidget } from '@/components/shared/quiet-ledger'
 
 export default function DataPage() {
   return (
@@ -11,11 +11,11 @@ export default function DataPage() {
           description="Export your ledger when you want a local copy or a spreadsheet backup."
         />
 
-        <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+        <TonalWidget tone="info" className="p-5 sm:p-5">
           <div className="flex items-start gap-3">
             <IconBadge icon={DatabaseBackup} tone="info" />
             <div className="min-w-0 space-y-2">
-              <h2 className="text-base font-semibold tracking-tight">
+              <h2 className="text-base font-semibold">
                 Export transactions
               </h2>
               <p className="text-sm leading-6 text-muted-foreground">
@@ -32,13 +32,13 @@ export default function DataPage() {
               </a>
             </div>
           </div>
-        </div>
+        </TonalWidget>
       </div>
 
-      <aside className="rounded-3xl border border-destructive/20 bg-card/70 p-5 shadow-sm shadow-foreground/5">
+      <TonalWidget tone="warning" className="p-5 sm:p-5">
         <IconBadge icon={ShieldAlert} tone="warning" />
         <div className="mt-4 space-y-2">
-          <h2 className="text-base font-semibold tracking-tight text-destructive">
+          <h2 className="text-base font-semibold text-destructive">
             Data safety
           </h2>
           <p className="text-sm leading-6 text-muted-foreground">
@@ -46,7 +46,7 @@ export default function DataPage() {
             you need a copy of your data before any manual cleanup.
           </p>
         </div>
-      </aside>
+      </TonalWidget>
     </section>
   )
 }

--- a/src/components/budgets/BudgetCard.tsx
+++ b/src/components/budgets/BudgetCard.tsx
@@ -1,7 +1,16 @@
 'use client'
 import { useTransition } from 'react'
+import { Gauge, Trash2, WalletCards } from 'lucide-react'
+
 import { deleteBudget } from '@/app/actions/budgets'
-import { FinancialAmount, ProgressMeter, StatusPill } from '@/components/shared/quiet-ledger'
+import {
+  AmountBox,
+  FinancialAmount,
+  IconBadge,
+  ProgressMeter,
+  StatusPill,
+  TonalWidget,
+} from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import type { Budget } from '@/lib/db/schema'
 
@@ -27,13 +36,16 @@ export function BudgetCard({ budget, spent }: Props) {
   }
 
   return (
-    <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+    <TonalWidget tone="budget" className="space-y-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <p className="truncate text-base font-semibold tracking-tight">{budget.name}</p>
+        <div className="flex min-w-0 items-start gap-3">
+          <IconBadge icon={Gauge} tone="budget" className="size-12 rounded-[1.35rem]" />
+          <div className="min-w-0 space-y-1">
+          <p className="truncate text-base font-semibold">{budget.name}</p>
           <div className="flex flex-wrap gap-2">
             <StatusPill className="capitalize">{budget.periodType}</StatusPill>
             <StatusPill tone={tone}>{status}</StatusPill>
+          </div>
           </div>
         </div>
         <span className="shrink-0 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
@@ -41,36 +53,32 @@ export function BudgetCard({ budget, spent }: Props) {
         </span>
       </div>
 
-      <div className="mt-5 space-y-1">
+      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5">
         <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
           Planned
         </p>
-        <p className="financial-display text-3xl font-bold tracking-tight">
+        <p className="financial-display mt-2 text-3xl font-bold">
           <FinancialAmount amount={total} currency={budget.currency} sign="never" />
         </p>
       </div>
 
-      <div className="mt-5">
+      <div>
         <ProgressMeter value={spent} max={total} tone={tone} label="Spent so far" />
         <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
-          <div className="rounded-2xl bg-muted/50 p-3">
-            <p className="text-xs text-muted-foreground">Spent</p>
-            <p className="font-semibold">
-              <FinancialAmount amount={spent} currency={budget.currency} sign="never" />
-            </p>
-          </div>
-          <div className="rounded-2xl bg-muted/50 p-3">
-            <p className="text-xs text-muted-foreground">
-              {remaining >= 0 ? 'Left' : 'Over'}
-            </p>
-            <p className="font-semibold">
-              <FinancialAmount
-                amount={Math.abs(remaining)}
-                currency={budget.currency}
-                sign="never"
-              />
-            </p>
-          </div>
+          <AmountBox
+            label="Spent"
+            amount={spent}
+            currency={budget.currency}
+            icon={WalletCards}
+            tone={tone}
+          />
+          <AmountBox
+            label={remaining >= 0 ? 'Left' : 'Over'}
+            amount={Math.abs(remaining)}
+            currency={budget.currency}
+            icon={WalletCards}
+            tone={remaining >= 0 ? 'positive' : 'negative'}
+          />
         </div>
       </div>
 
@@ -81,8 +89,9 @@ export function BudgetCard({ budget, spent }: Props) {
         onClick={handleDelete}
         disabled={isPending}
       >
+        <Trash2 className="size-4" />
         {isPending ? 'Deleting...' : 'Delete budget'}
       </Button>
-    </div>
+    </TonalWidget>
   )
 }

--- a/src/components/budgets/GoalCard.tsx
+++ b/src/components/budgets/GoalCard.tsx
@@ -1,7 +1,16 @@
 'use client'
 import { useState, useTransition } from 'react'
+import { PiggyBank, Target, Trash2 } from 'lucide-react'
+
 import { contributeToGoal, deleteSavingsGoal } from '@/app/actions/budgets'
-import { FinancialAmount, ProgressMeter, StatusPill } from '@/components/shared/quiet-ledger'
+import {
+  AmountBox,
+  FinancialAmount,
+  IconBadge,
+  ProgressMeter,
+  StatusPill,
+  TonalWidget,
+} from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -69,13 +78,16 @@ export function GoalCard({ goal }: Props) {
   }
 
   return (
-    <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+    <TonalWidget tone="goal" className="space-y-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <p className="truncate text-base font-semibold tracking-tight">{goal.name}</p>
-          {goal.description && (
-            <p className="truncate text-sm text-muted-foreground">{goal.description}</p>
-          )}
+        <div className="flex min-w-0 items-start gap-3">
+          <IconBadge icon={Target} tone="goal" className="size-12 rounded-[1.35rem]" />
+          <div className="min-w-0 space-y-1">
+            <p className="truncate text-base font-semibold">{goal.name}</p>
+            {goal.description && (
+              <p className="truncate text-sm text-muted-foreground">{goal.description}</p>
+            )}
+          </div>
         </div>
         <StatusPill
           tone={STATUS_TONES[goal.status as keyof typeof STATUS_TONES] ?? 'neutral'}
@@ -85,11 +97,11 @@ export function GoalCard({ goal }: Props) {
         </StatusPill>
       </div>
 
-      <div className="mt-5 space-y-1">
+      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5">
         <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
           Saved
         </p>
-        <p className="financial-display text-3xl font-bold tracking-tight">
+        <p className="financial-display mt-2 text-3xl font-bold">
           <FinancialAmount amount={current} currency={goal.currency} sign="never" />
         </p>
         <p className="text-sm text-muted-foreground">
@@ -97,23 +109,26 @@ export function GoalCard({ goal }: Props) {
         </p>
       </div>
 
-      <div className="mt-5">
+      <div>
         <ProgressMeter
           value={current}
           max={target}
           tone={STATUS_PROGRESS_TONES[goal.status as keyof typeof STATUS_PROGRESS_TONES] ?? 'primary'}
           label="Goal progress"
         />
-        <div className="mt-3 rounded-2xl bg-muted/50 p-3 text-sm">
-          <p className="text-xs text-muted-foreground">Still needed</p>
-          <p className="font-semibold">
-            <FinancialAmount amount={remaining} currency={goal.currency} sign="never" />
-          </p>
+        <div className="mt-3">
+          <AmountBox
+            label="Still needed"
+            amount={remaining}
+            currency={goal.currency}
+            icon={PiggyBank}
+            tone={remaining === 0 ? 'positive' : 'goal'}
+          />
         </div>
       </div>
 
       {deadlineDate && (
-        <p className="mt-4 text-xs text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           Deadline: {deadlineDate.toLocaleDateString()}{' '}
           {daysRemaining !== null && (
             <span className={daysRemaining < 0 ? 'text-destructive' : ''}>
@@ -123,7 +138,7 @@ export function GoalCard({ goal }: Props) {
         </p>
       )}
 
-      <div className="mt-5 flex gap-2">
+      <div className="flex gap-2">
         {goal.status === 'active' && (
           <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger render={<Button variant="default" size="sm" className="flex-1 rounded-2xl" />}>
@@ -164,9 +179,10 @@ export function GoalCard({ goal }: Props) {
           onClick={handleDelete}
           disabled={isPending}
         >
+          <Trash2 className="size-4" />
           {isPending ? 'Deleting...' : 'Delete'}
         </Button>
       </div>
-    </div>
+    </TonalWidget>
   )
 }

--- a/src/components/dashboard/CashFlowSummary.tsx
+++ b/src/components/dashboard/CashFlowSummary.tsx
@@ -9,10 +9,11 @@ import {
 
 import type { Transaction } from "@/lib/db/schema";
 import {
-  FinancialAmount,
-  IconBadge,
+  AmountBox,
   ProgressMeter,
   StatusPill,
+  TonalWidget,
+  WidgetHeading,
 } from "@/components/shared/quiet-ledger";
 
 interface Props {
@@ -43,90 +44,53 @@ export function CashFlowSummary({ transactions, currency }: Props) {
   const netTone = net > 0 ? "positive" : net < 0 ? "negative" : "neutral";
 
   return (
-    <section className="rounded-[2rem] border bg-card/85 p-5 shadow-sm shadow-foreground/5 backdrop-blur sm:p-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <IconBadge icon={WalletCards} tone="primary" className="size-10" />
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
-                Month in motion
-              </p>
-              <h2 className="text-xl font-bold tracking-tight">Cash flow</h2>
-            </div>
-          </div>
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-            A simple view of money coming in, money going out, and whether this
-            month is staying healthy.
-          </p>
-        </div>
+    <TonalWidget tone="cash" className="space-y-6">
+      <WidgetHeading
+        icon={WalletCards}
+        tone="cash"
+        eyebrow="Month in motion"
+        title="Cash flow"
+        description="Money coming in, money going out, and whether this month is staying healthy."
+        action={
+          <StatusPill tone={netTone}>
+            {net > 0
+              ? "Ahead this month"
+              : net < 0
+                ? "Spending ahead"
+                : "Balanced"}
+          </StatusPill>
+        }
+      />
 
-        <StatusPill tone={netTone}>
-          {net > 0
-            ? "Ahead this month"
-            : net < 0
-              ? "Spending ahead"
-              : "Balanced"}
-        </StatusPill>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <AmountBox
+          label="Income"
+          amount={income}
+          currency={currency}
+          icon={ArrowUpRight}
+          tone="positive"
+          count="Money received this month"
+        />
+        <AmountBox
+          label="Expenses"
+          amount={expense}
+          currency={currency}
+          icon={ArrowDownLeft}
+          tone="negative"
+          count="Spending recorded this month"
+        />
+        <AmountBox
+          label="Net"
+          amount={net}
+          currency={currency}
+          icon={Landmark}
+          tone={netTone}
+          sign="always"
+          count="Income less expenses"
+        />
       </div>
 
-      <div className="mt-6 grid gap-3 sm:grid-cols-3">
-        <div className="rounded-3xl border bg-background/70 p-4">
-          <div className="flex items-center gap-3">
-            <IconBadge
-              icon={ArrowUpRight}
-              tone="positive"
-              className="size-10"
-            />
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                Income
-              </p>
-              <p className="mt-1 text-lg font-bold text-emerald-700 dark:text-emerald-300">
-                <FinancialAmount amount={income} currency={currency} />
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-3xl border bg-background/70 p-4">
-          <div className="flex items-center gap-3">
-            <IconBadge
-              icon={ArrowDownLeft}
-              tone="negative"
-              className="size-10"
-            />
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                Expenses
-              </p>
-              <p className="mt-1 text-lg font-bold text-rose-700 dark:text-rose-300">
-                <FinancialAmount amount={expense} currency={currency} />
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-3xl border bg-background/70 p-4">
-          <div className="flex items-center gap-3">
-            <IconBadge icon={Landmark} tone={netTone} className="size-10" />
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                Net
-              </p>
-              <p className="mt-1 text-lg font-bold">
-                <FinancialAmount
-                  amount={net}
-                  currency={currency}
-                  sign="always"
-                />
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-5 rounded-3xl border bg-background/70 p-4">
+      <div className="rounded-3xl border bg-background/70 p-4 shadow-sm shadow-foreground/5">
         <ProgressMeter
           value={expensePace}
           tone={expensePace > 85 ? "warning" : "positive"}
@@ -141,6 +105,6 @@ export function CashFlowSummary({ transactions, currency }: Props) {
           </span>
         </div>
       </div>
-    </section>
+    </TonalWidget>
   );
 }

--- a/src/components/dashboard/NetworthCard.tsx
+++ b/src/components/dashboard/NetworthCard.tsx
@@ -2,10 +2,12 @@
 import { Landmark, PiggyBank, TrendingUp, WalletCards } from "lucide-react";
 import type { NetworthData } from "@/lib/utils/networth";
 import {
+  AmountBox,
   FinancialAmount,
-  IconBadge,
   ProgressMeter,
   StatusPill,
+  TonalWidget,
+  WidgetHeading,
 } from "@/components/shared/quiet-ledger";
 
 interface Props extends NetworthData {
@@ -34,112 +36,86 @@ export function NetworthCard({
     networth > 0 ? "positive" : networth < 0 ? "negative" : "neutral";
 
   return (
-    <section className="relative overflow-hidden rounded-[2rem] border bg-card/90 p-5 shadow-sm shadow-foreground/5 backdrop-blur sm:p-7">
-      <div className="absolute inset-0 bg-gradient-to-br from-primary/12 via-transparent to-sky-500/10" />
-      <div className="absolute -right-20 -top-24 size-56 rounded-full bg-primary/10 blur-3xl" />
-      <div className="absolute -bottom-28 left-10 size-56 rounded-full bg-emerald-400/10 blur-3xl" />
+    <TonalWidget tone="primary" className="space-y-6">
+      <WidgetHeading
+        icon={PiggyBank}
+        tone="primary"
+        eyebrow="Your money home"
+        title="Net worth snapshot"
+        description="Assets minus liabilities across cash, investments, and debt."
+        action={
+          <StatusPill tone={networthTone}>
+            {networth > 0
+              ? "Positive net worth"
+              : networth < 0
+                ? "Liabilities ahead"
+                : "Getting started"}
+          </StatusPill>
+        }
+      />
 
-      <div className="relative space-y-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-3">
-            <StatusPill tone={networthTone}>
-              {networth > 0
-                ? "Positive net worth"
-                : networth < 0
-                  ? "Liabilities ahead"
-                  : "Getting started"}
-            </StatusPill>
+      <div className="rounded-[1.75rem] border bg-background/75 p-5 shadow-sm shadow-foreground/5 sm:p-6">
+        <p className="text-sm font-medium text-muted-foreground">
+          Family balance
+        </p>
+        <h2 className="financial-display mt-2 text-4xl font-bold text-foreground sm:text-5xl">
+          <FinancialAmount amount={networth} currency={currency} />
+        </h2>
+        <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+          The calm headline number for the month: what you own, less what you
+          owe.
+        </p>
+      </div>
 
-            <div>
-              <p className="text-sm font-medium text-muted-foreground">
-                Your money home
-              </p>
-              <h2 className="financial-display mt-2 text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
-                <FinancialAmount amount={networth} currency={currency} />
-              </h2>
-              <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
-                Assets minus liabilities across cash, investments, and debt.
-                This is the number to keep calm, clear, and moving in the right
-                direction.
-              </p>
-            </div>
-          </div>
-
-          <IconBadge icon={PiggyBank} tone="primary" className="size-14" />
-        </div>
-
-        <div className="grid gap-3 sm:grid-cols-3">
-          <div className="rounded-3xl border bg-background/70 p-4">
-            <div className="flex items-center gap-3">
-              <IconBadge icon={WalletCards} tone="info" className="size-10" />
-              <div>
-                <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  Cash
-                </p>
-                <p className="mt-1 font-semibold tabular-nums">
-                  <FinancialAmount amount={totalCash} currency={currency} />
-                </p>
-              </div>
-            </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="space-y-3">
+          <AmountBox
+            label="Cash"
+            amount={totalCash}
+            currency={currency}
+            icon={WalletCards}
+            tone="cash"
+            count="Bank, wallet, cash, and savings balances"
+          />
             <ProgressMeter
               value={cashShare}
-              tone="info"
-              className="mt-4"
+              tone="cash"
               label="Asset share"
             />
-          </div>
+        </div>
 
-          <div className="rounded-3xl border bg-background/70 p-4">
-            <div className="flex items-center gap-3">
-              <IconBadge
-                icon={TrendingUp}
-                tone="positive"
-                className="size-10"
-              />
-              <div>
-                <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  Investments
-                </p>
-                <p className="mt-1 font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">
-                  <FinancialAmount
-                    amount={totalInvestments}
-                    currency={currency}
-                  />
-                </p>
-              </div>
-            </div>
+        <div className="space-y-3">
+          <AmountBox
+            label="Investments"
+            amount={totalInvestments}
+            currency={currency}
+            icon={TrendingUp}
+            tone="investment"
+            count="Long-term assets and market holdings"
+          />
             <ProgressMeter
               value={investmentShare}
-              tone="positive"
-              className="mt-4"
+              tone="investment"
               label="Asset share"
             />
-          </div>
+        </div>
 
-          <div className="rounded-3xl border bg-background/70 p-4">
-            <div className="flex items-center gap-3">
-              <IconBadge icon={Landmark} tone="negative" className="size-10" />
-              <div>
-                <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                  Liabilities
-                </p>
-                <p className="mt-1 font-semibold tabular-nums text-rose-700 dark:text-rose-300">
-                  <FinancialAmount
-                    amount={totalLiabilities}
-                    currency={currency}
-                  />
-                </p>
-              </div>
-            </div>
+        <div className="space-y-3">
+          <AmountBox
+            label="Liabilities"
+            amount={totalLiabilities}
+            currency={currency}
+            icon={Landmark}
+            tone="loan"
+            count="Loans, obligations, and debt to watch"
+          />
             <ProgressMeter
               value={Math.min(liabilityRatio * 100, 100)}
               tone={liabilityRatio > 0.5 ? "negative" : "warning"}
-              className="mt-4"
               label="Liability load"
             />
-          </div>
         </div>
       </div>
-    </section>
+    </TonalWidget>
   );
 }

--- a/src/components/dashboard/RecentTransactions.tsx
+++ b/src/components/dashboard/RecentTransactions.tsx
@@ -16,6 +16,7 @@ import {
   IconBadge,
   SectionHeader,
   StatusPill,
+  TonalWidget,
 } from "@/components/shared/quiet-ledger";
 
 interface Props {
@@ -58,7 +59,7 @@ export function RecentTransactions({ transactions }: Props) {
           className="py-8"
         />
       ) : (
-        <div className="overflow-hidden rounded-[2rem] border bg-card/85 shadow-sm shadow-foreground/5 backdrop-blur">
+        <TonalWidget tone="neutral" className="space-y-2 p-3 sm:p-3">
           {transactions.map((transaction, index) => {
             const Icon = getTransactionIcon(transaction.type);
             const tone = getTransactionTone(transaction.type);
@@ -71,12 +72,16 @@ export function RecentTransactions({ transactions }: Props) {
               <div
                 key={transaction.id}
                 className={cn(
-                  "flex items-center justify-between gap-3 p-4 transition hover:bg-muted/40",
-                  index > 0 && "border-t",
+                  "flex items-center justify-between gap-3 rounded-[1.5rem] border bg-background/70 p-3 shadow-sm shadow-foreground/5 transition hover:bg-background sm:p-4",
+                  index === 0 && "border-primary/20",
                 )}
               >
                 <div className="flex min-w-0 items-center gap-3">
-                  <IconBadge icon={Icon} tone={tone} className="size-11" />
+                  <IconBadge
+                    icon={Icon}
+                    tone={tone}
+                    className="size-12 rounded-[1.35rem]"
+                  />
                   <div className="min-w-0">
                     <p className="truncate text-sm font-semibold text-foreground">
                       {transaction.note || "Untitled transaction"}
@@ -108,7 +113,7 @@ export function RecentTransactions({ transactions }: Props) {
               </div>
             );
           })}
-        </div>
+        </TonalWidget>
       )}
     </section>
   );

--- a/src/components/dashboard/UpcomingAlerts.tsx
+++ b/src/components/dashboard/UpcomingAlerts.tsx
@@ -16,6 +16,7 @@ import {
   IconBadge,
   SectionHeader,
   StatusPill,
+  TonalWidget,
 } from "@/components/shared/quiet-ledger";
 
 interface Props {
@@ -103,7 +104,7 @@ export function UpcomingAlerts({ loans, policies }: Props) {
         description="The next few money items worth keeping an eye on."
       />
 
-      <div className="overflow-hidden rounded-[2rem] border bg-card/85 shadow-sm shadow-foreground/5 backdrop-blur">
+      <TonalWidget tone="insurance" className="space-y-2 p-3 sm:p-3">
         {alerts.map((alert, index) => {
           const tone = getUrgencyTone(alert.daysUntil);
           const Icon = alert.kind === "loan" ? CreditCard : ShieldCheck;
@@ -111,12 +112,16 @@ export function UpcomingAlerts({ loans, policies }: Props) {
           return (
             <div
               key={alert.id}
-              className={`flex items-center justify-between gap-3 p-4 ${
-                index > 0 ? "border-t" : ""
+              className={`flex items-center justify-between gap-3 rounded-[1.5rem] border bg-background/70 p-3 shadow-sm shadow-foreground/5 sm:p-4 ${
+                index === 0 ? "border-primary/20" : ""
               }`}
             >
               <div className="flex min-w-0 items-center gap-3">
-                <IconBadge icon={Icon} tone={tone} className="size-11" />
+                <IconBadge
+                  icon={Icon}
+                  tone={alert.kind === "loan" ? "loan" : tone}
+                  className="size-12 rounded-[1.35rem]"
+                />
 
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
@@ -148,7 +153,7 @@ export function UpcomingAlerts({ loans, policies }: Props) {
             </div>
           );
         })}
-      </div>
+      </TonalWidget>
 
       {alerts.some((alert) => alert.daysUntil <= 7) && (
         <div className="flex items-start gap-2 rounded-3xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200">

--- a/src/components/insurance/PolicyCard.tsx
+++ b/src/components/insurance/PolicyCard.tsx
@@ -1,8 +1,15 @@
 'use client'
 import { useTransition } from 'react'
 import { differenceInDays } from 'date-fns'
+import { ShieldCheck, Trash2 } from 'lucide-react'
+
 import { deletePolicy } from '@/app/actions/insurance'
-import { FinancialAmount, StatusPill } from '@/components/shared/quiet-ledger'
+import {
+  FinancialAmount,
+  IconBadge,
+  StatusPill,
+  TonalWidget,
+} from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import type { InsurancePolicy } from '@/lib/db/schema'
 
@@ -41,29 +48,32 @@ export function PolicyCard({ policy }: Props) {
   }
 
   return (
-    <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+    <TonalWidget tone="insurance" className="space-y-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1 space-y-1">
-          <p className="truncate text-base font-semibold tracking-tight">{policy.name}</p>
-          <div className="flex flex-wrap gap-2">
-            <StatusPill tone="info">
-              {POLICY_TYPE_LABELS[policy.policyType] ?? policy.policyType}
-            </StatusPill>
-            {renewsSoon && <StatusPill tone="warning">Renews soon</StatusPill>}
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <IconBadge icon={ShieldCheck} tone="insurance" className="size-12 rounded-[1.35rem]" />
+          <div className="min-w-0 space-y-1">
+            <p className="truncate text-base font-semibold">{policy.name}</p>
+            <div className="flex flex-wrap gap-2">
+              <StatusPill tone="insurance">
+                {POLICY_TYPE_LABELS[policy.policyType] ?? policy.policyType}
+              </StatusPill>
+              {renewsSoon && <StatusPill tone="warning">Renews soon</StatusPill>}
+            </div>
           </div>
         </div>
         <StatusPill>{policy.currency}</StatusPill>
       </div>
 
       {policy.provider && (
-        <p className="mt-3 text-sm text-muted-foreground">{policy.provider}</p>
+        <p className="text-sm text-muted-foreground">{policy.provider}</p>
       )}
 
-      <div className="mt-5 space-y-1">
+      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5">
         <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
           Premium
         </p>
-        <p className="financial-display text-3xl font-bold tracking-tight">
+        <p className="financial-display mt-2 text-3xl font-bold">
           <FinancialAmount amount={Number(policy.premiumAmount)} currency={policy.currency} sign="never" />
           <span className="text-sm font-normal text-muted-foreground ml-1">
             / {FREQUENCY_LABELS[policy.premiumFrequency] ?? policy.premiumFrequency}
@@ -72,7 +82,7 @@ export function PolicyCard({ policy }: Props) {
       </div>
 
       {policy.coverageAmount && (
-        <div className="mt-5 rounded-2xl bg-muted/50 p-3 text-sm">
+        <div className="rounded-2xl border bg-background/70 p-3 text-sm">
           <span className="text-muted-foreground">Coverage: </span>
           <span className="font-medium">
             <FinancialAmount amount={Number(policy.coverageAmount)} currency={policy.currency} sign="never" />
@@ -81,7 +91,7 @@ export function PolicyCard({ policy }: Props) {
       )}
 
       {policy.renewalDate && (
-        <div className="mt-4 text-sm">
+        <div className="text-sm">
           <span className="text-muted-foreground">Renewal: </span>
           <span className={renewsSoon ? 'font-medium text-orange-600 dark:text-orange-400' : ''}>
             {policy.renewalDate}
@@ -95,12 +105,13 @@ export function PolicyCard({ policy }: Props) {
       <Button
         variant="outline"
         size="sm"
-        className="mt-5 w-full rounded-2xl text-destructive hover:text-destructive"
+        className="w-full rounded-2xl text-destructive hover:text-destructive"
         onClick={handleDelete}
         disabled={isPending}
       >
+        <Trash2 className="size-4" />
         {isPending ? 'Deleting...' : 'Delete policy'}
       </Button>
-    </div>
+    </TonalWidget>
   )
 }

--- a/src/components/investments/AssetCard.tsx
+++ b/src/components/investments/AssetCard.tsx
@@ -1,7 +1,14 @@
 'use client'
 import { useState, useTransition } from 'react'
+import { ChartNoAxesCombined, Trash2 } from 'lucide-react'
+
 import { updateInvestmentPrice, deleteInvestment } from '@/app/actions/investments'
-import { FinancialAmount, StatusPill } from '@/components/shared/quiet-ledger'
+import {
+  FinancialAmount,
+  IconBadge,
+  StatusPill,
+  TonalWidget,
+} from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -64,27 +71,30 @@ export function AssetCard({ investment }: Props) {
   }
 
   return (
-    <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+    <TonalWidget tone="investment" className="space-y-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <p className="truncate text-base font-semibold tracking-tight">{investment.name}</p>
-          <StatusPill tone="primary">
-            {ASSET_TYPE_LABELS[investment.assetType] ?? investment.assetType}
-          </StatusPill>
+        <div className="flex min-w-0 items-start gap-3">
+          <IconBadge icon={ChartNoAxesCombined} tone="investment" className="size-12 rounded-[1.35rem]" />
+          <div className="min-w-0 space-y-1">
+            <p className="truncate text-base font-semibold">{investment.name}</p>
+            <StatusPill tone="investment">
+              {ASSET_TYPE_LABELS[investment.assetType] ?? investment.assetType}
+            </StatusPill>
+          </div>
         </div>
         <StatusPill>{investment.currency}</StatusPill>
       </div>
 
-      <div className="mt-5 space-y-1">
+      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5">
         <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
           Current value
         </p>
-        <p className="financial-display text-3xl font-bold tracking-tight">
+        <p className="financial-display mt-2 text-3xl font-bold">
           <FinancialAmount amount={currentValue} currency={investment.currency} sign="never" />
         </p>
       </div>
 
-      <div className="mt-5 space-y-2 text-sm">
+      <div className="space-y-2 rounded-[1.5rem] border bg-background/70 p-4 text-sm">
         {buy > 0 && (
           <div className="flex justify-between gap-4">
             <span className="text-muted-foreground">Invested</span>
@@ -109,7 +119,7 @@ export function AssetCard({ investment }: Props) {
         )}
       </div>
 
-      <div className="mt-5 flex gap-2">
+      <div className="flex gap-2">
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger render={<Button variant="outline" size="sm" className="flex-1 rounded-2xl" />}>
             Update price
@@ -147,9 +157,10 @@ export function AssetCard({ investment }: Props) {
           onClick={handleDelete}
           disabled={isPending}
         >
+          <Trash2 className="size-4" />
           Delete
         </Button>
       </div>
-    </div>
+    </TonalWidget>
   )
 }

--- a/src/components/loans/LoanCard.tsx
+++ b/src/components/loans/LoanCard.tsx
@@ -1,7 +1,15 @@
 'use client'
 import { useTransition } from 'react'
+import { Landmark, Trash2 } from 'lucide-react'
+
 import { deleteLoan } from '@/app/actions/loans'
-import { FinancialAmount, ProgressMeter, StatusPill } from '@/components/shared/quiet-ledger'
+import {
+  FinancialAmount,
+  IconBadge,
+  ProgressMeter,
+  StatusPill,
+  TonalWidget,
+} from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import type { Loan } from '@/lib/db/schema'
 
@@ -32,27 +40,30 @@ export function LoanCard({ loan }: Props) {
   }
 
   return (
-    <div className="rounded-3xl border bg-card/85 p-5 shadow-sm shadow-foreground/5">
+    <TonalWidget tone="loan" className="space-y-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <p className="truncate text-base font-semibold tracking-tight">{loan.name}</p>
-          <StatusPill tone="negative">
-            {LOAN_TYPE_LABELS[loan.loanType] ?? loan.loanType}
-          </StatusPill>
+        <div className="flex min-w-0 items-start gap-3">
+          <IconBadge icon={Landmark} tone="loan" className="size-12 rounded-[1.35rem]" />
+          <div className="min-w-0 space-y-1">
+            <p className="truncate text-base font-semibold">{loan.name}</p>
+            <StatusPill tone="loan">
+              {LOAN_TYPE_LABELS[loan.loanType] ?? loan.loanType}
+            </StatusPill>
+          </div>
         </div>
         <StatusPill>{loan.currency}</StatusPill>
       </div>
 
-      <div className="mt-5 space-y-1">
+      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5">
         <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
           Outstanding
         </p>
-        <p className="financial-display text-3xl font-bold tracking-tight text-rose-700 dark:text-rose-300">
+        <p className="financial-display mt-2 text-3xl font-bold text-rose-700 dark:text-rose-300">
           <FinancialAmount amount={outstanding} currency={loan.currency} sign="never" />
         </p>
       </div>
 
-      <div className="mt-5 space-y-2 text-sm">
+      <div className="space-y-2 rounded-[1.5rem] border bg-background/70 p-4 text-sm">
         <div className="flex justify-between">
           <span className="text-muted-foreground">Principal</span>
           <span className="font-medium">
@@ -75,19 +86,20 @@ export function LoanCard({ loan }: Props) {
         </div>
       </div>
 
-      <div className="mt-5">
+      <div>
         <ProgressMeter value={paidPct} tone="positive" label="Repaid" />
       </div>
 
       <Button
         variant="outline"
         size="sm"
-        className="mt-5 w-full rounded-2xl text-destructive hover:text-destructive"
+        className="w-full rounded-2xl text-destructive hover:text-destructive"
         onClick={handleDelete}
         disabled={isPending}
       >
+        <Trash2 className="size-4" />
         {isPending ? 'Deleting...' : 'Delete loan'}
       </Button>
-    </div>
+    </TonalWidget>
   )
 }

--- a/src/components/settings/AccountsClient.tsx
+++ b/src/components/settings/AccountsClient.tsx
@@ -6,6 +6,7 @@ import {
   IconBadge,
   SectionHeader,
   StatusPill,
+  TonalWidget,
 } from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -132,9 +133,10 @@ export function AccountsClient({ accountList }: AccountsClientProps) {
           {accountList.map((account) => {
             const meta = accountMeta[account.type]
             return (
-              <div
+              <TonalWidget
                 key={account.id}
-                className="flex items-center justify-between gap-3 rounded-3xl border bg-card/85 p-4 shadow-sm shadow-foreground/5"
+                tone={meta.tone}
+                className="flex items-center justify-between gap-3 p-4 sm:p-4"
               >
                 <div className="flex min-w-0 items-center gap-3">
                   <IconBadge icon={meta.icon} tone={meta.tone} className="size-11" />
@@ -147,7 +149,7 @@ export function AccountsClient({ accountList }: AccountsClientProps) {
                   </div>
                 </div>
                 <DeleteAccountButton id={account.id} />
-              </div>
+              </TonalWidget>
             )
           })}
         </div>

--- a/src/components/settings/CategoriesClient.tsx
+++ b/src/components/settings/CategoriesClient.tsx
@@ -6,6 +6,7 @@ import {
   IconBadge,
   SectionHeader,
   StatusPill,
+  TonalWidget,
 } from '@/components/shared/quiet-ledger'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -84,7 +85,7 @@ function CategoryRow({ category, userId }: { category: Category; userId: string 
   const Icon = category.type === 'income' ? ArrowUpRight : ArrowDownRight
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-3xl border bg-card/85 p-4 shadow-sm shadow-foreground/5">
+    <TonalWidget tone={tone} className="flex items-center justify-between gap-3 p-4 sm:p-4">
       <div className="flex min-w-0 items-center gap-3">
         <IconBadge icon={Icon} tone={tone} className="size-11" />
         <div className="min-w-0">
@@ -106,7 +107,7 @@ function CategoryRow({ category, userId }: { category: Category; userId: string 
         </div>
       </div>
       {isOwned && <DeleteCategoryButton id={category.id} />}
-    </div>
+    </TonalWidget>
   )
 }
 

--- a/src/components/shared/quiet-ledger.tsx
+++ b/src/components/shared/quiet-ledger.tsx
@@ -14,7 +14,19 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 
-type Tone = 'neutral' | 'positive' | 'negative' | 'warning' | 'info' | 'primary'
+type Tone =
+  | 'neutral'
+  | 'positive'
+  | 'negative'
+  | 'warning'
+  | 'info'
+  | 'primary'
+  | 'cash'
+  | 'budget'
+  | 'goal'
+  | 'investment'
+  | 'loan'
+  | 'insurance'
 
 const toneStyles: Record<
   Tone,
@@ -67,6 +79,48 @@ const toneStyles: Record<
     border: 'border-primary/20',
     icon: 'text-primary',
     ring: 'ring-primary/20',
+  },
+  cash: {
+    text: 'text-sky-800 dark:text-sky-200',
+    bg: 'bg-sky-100/80 dark:bg-sky-950/50',
+    border: 'border-sky-200/90 dark:border-sky-900',
+    icon: 'text-sky-700 dark:text-sky-300',
+    ring: 'ring-sky-200/90 dark:ring-sky-900',
+  },
+  budget: {
+    text: 'text-amber-800 dark:text-amber-200',
+    bg: 'bg-amber-100/80 dark:bg-amber-950/50',
+    border: 'border-amber-200/90 dark:border-amber-900',
+    icon: 'text-amber-700 dark:text-amber-300',
+    ring: 'ring-amber-200/90 dark:ring-amber-900',
+  },
+  goal: {
+    text: 'text-teal-800 dark:text-teal-200',
+    bg: 'bg-teal-100/80 dark:bg-teal-950/50',
+    border: 'border-teal-200/90 dark:border-teal-900',
+    icon: 'text-teal-700 dark:text-teal-300',
+    ring: 'ring-teal-200/90 dark:ring-teal-900',
+  },
+  investment: {
+    text: 'text-violet-800 dark:text-violet-200',
+    bg: 'bg-violet-100/80 dark:bg-violet-950/50',
+    border: 'border-violet-200/90 dark:border-violet-900',
+    icon: 'text-violet-700 dark:text-violet-300',
+    ring: 'ring-violet-200/90 dark:ring-violet-900',
+  },
+  loan: {
+    text: 'text-orange-800 dark:text-orange-200',
+    bg: 'bg-orange-100/80 dark:bg-orange-950/50',
+    border: 'border-orange-200/90 dark:border-orange-900',
+    icon: 'text-orange-700 dark:text-orange-300',
+    ring: 'ring-orange-200/90 dark:ring-orange-900',
+  },
+  insurance: {
+    text: 'text-indigo-800 dark:text-indigo-200',
+    bg: 'bg-indigo-100/80 dark:bg-indigo-950/50',
+    border: 'border-indigo-200/90 dark:border-indigo-900',
+    icon: 'text-indigo-700 dark:text-indigo-300',
+    ring: 'ring-indigo-200/90 dark:ring-indigo-900',
   },
 }
 
@@ -125,7 +179,7 @@ export function PageHeader({
         <div className="space-y-1">
           <h1
             data-display-text
-            className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+            className="text-2xl font-bold text-foreground sm:text-3xl"
           >
             {title}
           </h1>
@@ -158,7 +212,7 @@ export function SectionHeader({
       <div className="min-w-0 space-y-1">
         <h2
           data-display-text
-          className="text-base font-semibold tracking-tight text-foreground"
+          className="text-base font-semibold text-foreground"
         >
           {title}
         </h2>
@@ -294,6 +348,104 @@ export function IconBadge({
   )
 }
 
+export function TonalWidget({
+  children,
+  tone = 'neutral',
+  className,
+}: {
+  children: React.ReactNode
+  tone?: Tone
+  className?: string
+}) {
+  return (
+    <section
+      className={cn(
+        'relative overflow-hidden rounded-[2rem] border p-5 shadow-sm shadow-foreground/5 sm:p-6',
+        toneStyles[tone].bg,
+        toneStyles[tone].border,
+        className
+      )}
+    >
+      {children}
+    </section>
+  )
+}
+
+export function WidgetHeading({
+  icon: Icon,
+  tone = 'primary',
+  eyebrow,
+  title,
+  description,
+  action,
+}: {
+  icon: LucideIcon
+  tone?: Tone
+  eyebrow?: string
+  title: string
+  description?: React.ReactNode
+  action?: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 items-start gap-3">
+        <IconBadge icon={Icon} tone={tone} className="size-12 rounded-[1.35rem]" />
+        <div className="min-w-0 space-y-1">
+          {eyebrow && (
+            <p className={cn('text-xs font-semibold uppercase tracking-[0.14em]', toneStyles[tone].text)}>
+              {eyebrow}
+            </p>
+          )}
+          <h2 data-display-text className="text-xl font-bold text-foreground">
+            {title}
+          </h2>
+          {description && (
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  )
+}
+
+export function AmountBox({
+  label,
+  amount,
+  currency,
+  count,
+  icon: Icon,
+  tone = 'neutral',
+  sign = 'never',
+}: {
+  label: string
+  amount: number
+  currency: string
+  count?: React.ReactNode
+  icon?: LucideIcon
+  tone?: Tone
+  sign?: 'auto' | 'always' | 'never'
+}) {
+  return (
+    <div className="rounded-3xl border bg-background/70 p-4 shadow-sm shadow-foreground/5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            {label}
+          </p>
+          <p className={cn('mt-2 text-xl font-bold', toneStyles[tone].text)}>
+            <FinancialAmount amount={amount} currency={currency} sign={sign} />
+          </p>
+        </div>
+        {Icon && <IconBadge icon={Icon} tone={tone} className="size-10" />}
+      </div>
+      {count && <p className="mt-3 text-xs leading-5 text-muted-foreground">{count}</p>}
+    </div>
+  )
+}
+
 export function MetricCard({
   label,
   value,
@@ -326,7 +478,7 @@ export function MetricCard({
             <CardDescription className="text-xs font-medium uppercase tracking-[0.14em]">
               {label}
             </CardDescription>
-            <CardTitle className="financial-display text-2xl font-bold tracking-tight sm:text-3xl">
+            <CardTitle className="financial-display text-2xl font-bold sm:text-3xl">
               {value}
             </CardTitle>
           </div>
@@ -374,6 +526,12 @@ export function ProgressMeter({
             tone === 'warning' && 'bg-amber-500',
             tone === 'info' && 'bg-sky-500',
             tone === 'primary' && 'bg-primary',
+            tone === 'cash' && 'bg-sky-500',
+            tone === 'budget' && 'bg-amber-500',
+            tone === 'goal' && 'bg-teal-500',
+            tone === 'investment' && 'bg-violet-500',
+            tone === 'loan' && 'bg-orange-500',
+            tone === 'insurance' && 'bg-indigo-500',
             tone === 'neutral' && 'bg-muted-foreground'
           )}
           style={{ width: `${percentage}%` }}

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -1,10 +1,14 @@
 "use client";
 import { useActionState } from "react";
 import { useSearchParams } from "next/navigation";
+import { ArrowDownLeft, ArrowLeftRight, ArrowUpRight } from "lucide-react";
+
 import { createTransaction } from "@/app/actions/transactions";
+import { IconBadge } from "@/components/shared/quiet-ledger";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type { Account, Category } from "@/lib/db/schema";
 
 interface Props {
@@ -28,28 +32,48 @@ export function TransactionForm({ accounts, categories }: Props) {
     (category) => category.type === "expense",
   );
   const hasAccounts = accounts.length > 0;
+  const transactionTypes = [
+    {
+      value: "expense",
+      label: "Expense",
+      icon: ArrowDownLeft,
+      tone: "negative" as const,
+    },
+    {
+      value: "income",
+      label: "Income",
+      icon: ArrowUpRight,
+      tone: "positive" as const,
+    },
+    {
+      value: "transfer",
+      label: "Transfer",
+      icon: ArrowLeftRight,
+      tone: "info" as const,
+    },
+  ];
 
   return (
     <form action={formAction} className="space-y-5">
-      <div className="rounded-3xl border bg-muted/40 p-1">
-        <div className="grid grid-cols-3 gap-1">
-          {[
-            ["expense", "Expense"],
-            ["income", "Income"],
-            ["transfer", "Transfer"],
-          ].map(([value, label]) => (
+      <div className="rounded-3xl border bg-primary/10 p-2">
+        <div className="grid grid-cols-3 gap-2">
+          {transactionTypes.map((item) => (
             <label
-              key={value}
-              className="cursor-pointer rounded-2xl px-3 py-2 text-center text-sm font-medium text-muted-foreground transition has-[:checked]:bg-card has-[:checked]:text-foreground has-[:checked]:shadow-sm"
+              key={item.value}
+              className={cn(
+                "flex cursor-pointer flex-col items-center gap-2 rounded-[1.35rem] border border-transparent px-2 py-3 text-center text-xs font-semibold text-muted-foreground transition",
+                "has-[:checked]:border-primary/20 has-[:checked]:bg-background has-[:checked]:text-foreground has-[:checked]:shadow-sm",
+              )}
             >
               <input
                 type="radio"
                 name="type"
-                value={value}
-                defaultChecked={value === defaultType}
+                value={item.value}
+                defaultChecked={item.value === defaultType}
                 className="sr-only"
               />
-              {label}
+              <IconBadge icon={item.icon} tone={item.tone} className="size-10" />
+              {item.label}
             </label>
           ))}
         </div>
@@ -67,7 +91,7 @@ export function TransactionForm({ accounts, categories }: Props) {
             inputMode="decimal"
             placeholder="0.00"
             required
-            className="h-14 text-2xl font-semibold tabular-nums"
+            className="h-14 rounded-2xl text-2xl font-semibold tabular-nums"
           />
           <Input
             id="currency"
@@ -75,7 +99,7 @@ export function TransactionForm({ accounts, categories }: Props) {
             defaultValue={defaultCurrency}
             maxLength={3}
             required
-            className="h-14 text-center font-semibold uppercase"
+            className="h-14 rounded-2xl text-center font-semibold uppercase"
           />
         </div>
       </div>
@@ -88,7 +112,7 @@ export function TransactionForm({ accounts, categories }: Props) {
             id="accountId"
             required
             disabled={!hasAccounts}
-            className="h-11 w-full rounded-xl border border-input bg-background px-3 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+            className="h-11 w-full rounded-2xl border border-input bg-background px-3 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
           >
             {hasAccounts ? (
               accounts.map((account) => (
@@ -110,7 +134,7 @@ export function TransactionForm({ accounts, categories }: Props) {
             type="date"
             required
             defaultValue={new Date().toISOString().slice(0, 10)}
-            className="h-11"
+            className="h-11 rounded-2xl"
           />
         </div>
       </div>
@@ -120,7 +144,7 @@ export function TransactionForm({ accounts, categories }: Props) {
         <select
           name="categoryId"
           id="categoryId"
-          className="h-11 w-full rounded-xl border border-input bg-background px-3 text-sm shadow-sm"
+          className="h-11 w-full rounded-2xl border border-input bg-background px-3 text-sm shadow-sm"
         >
           <option value="">No category yet</option>
           {expenseCategories.length > 0 && (
@@ -152,7 +176,7 @@ export function TransactionForm({ accounts, categories }: Props) {
           type="text"
           placeholder="Coffee, rent, salary, transfer…"
           autoComplete="off"
-          className="h-11"
+          className="h-11 rounded-2xl"
         />
       </div>
 

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDownLeft,
   ArrowLeftRight,
   ArrowUpRight,
+  CircleDollarSign,
   Search,
   Trash2,
   WalletCards,
@@ -17,12 +18,23 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/format";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { EmptyState, StatusPill } from "@/components/shared/quiet-ledger";
+import {
+  AmountBox,
+  EmptyState,
+  IconBadge,
+  StatusPill,
+  TonalWidget,
+} from "@/components/shared/quiet-ledger";
 
 interface Props {
   transactions: Transaction[];
   accounts: Array<{ id: string; name: string; currency: string }>;
-  categories: Array<{ id: string; name: string; type: "income" | "expense" }>;
+  categories: Array<{
+    id: string;
+    name: string;
+    type: "income" | "expense";
+    color?: string | null;
+  }>;
 }
 
 type TransactionFilter = "all" | Transaction["type"];
@@ -65,6 +77,12 @@ function getTransactionIcon(type: Transaction["type"]) {
   if (type === "income") return ArrowUpRight;
   if (type === "expense") return ArrowDownLeft;
   return ArrowLeftRight;
+}
+
+function getSignedAmount(transaction: Transaction) {
+  return transaction.type === "expense"
+    ? -Number(transaction.amount)
+    : Number(transaction.amount);
 }
 
 function getDateLabel(date: string) {
@@ -143,6 +161,42 @@ export function TransactionList({ transactions, accounts, categories }: Props) {
     [filteredTransactions],
   );
 
+  const summary = useMemo(() => {
+    return filteredTransactions.reduce(
+      (totals, transaction) => {
+        const amount = Number(transaction.amount);
+
+        if (transaction.type === "income") {
+          totals.income += amount;
+          totals.incomeCount += 1;
+        }
+
+        if (transaction.type === "expense") {
+          totals.expense += amount;
+          totals.expenseCount += 1;
+        }
+
+        if (transaction.type === "transfer") {
+          totals.transfer += amount;
+          totals.transferCount += 1;
+        }
+
+        return totals;
+      },
+      {
+        income: 0,
+        expense: 0,
+        transfer: 0,
+        incomeCount: 0,
+        expenseCount: 0,
+        transferCount: 0,
+      },
+    );
+  }, [filteredTransactions]);
+
+  const summaryCurrency =
+    filteredTransactions[0]?.currency ?? accounts[0]?.currency ?? "INR";
+
   if (transactions.length === 0) {
     return (
       <EmptyState
@@ -155,7 +209,34 @@ export function TransactionList({ transactions, accounts, categories }: Props) {
 
   return (
     <div className="space-y-5">
-      <div className="rounded-3xl border bg-card/85 p-3 shadow-sm shadow-foreground/5 backdrop-blur">
+      <div className="grid gap-3 md:grid-cols-3">
+        <AmountBox
+          label="Income"
+          amount={summary.income}
+          currency={summaryCurrency}
+          icon={ArrowUpRight}
+          tone="positive"
+          count={`${summary.incomeCount} entries in view`}
+        />
+        <AmountBox
+          label="Expenses"
+          amount={summary.expense}
+          currency={summaryCurrency}
+          icon={ArrowDownLeft}
+          tone="negative"
+          count={`${summary.expenseCount} entries in view`}
+        />
+        <AmountBox
+          label="Transfers"
+          amount={summary.transfer}
+          currency={summaryCurrency}
+          icon={ArrowLeftRight}
+          tone="info"
+          count={`${summary.transferCount} entries in view`}
+        />
+      </div>
+
+      <TonalWidget tone="primary" className="p-3 sm:p-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="relative flex-1">
             <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
@@ -214,7 +295,7 @@ export function TransactionList({ transactions, accounts, categories }: Props) {
             ))}
           </select>
         </div>
-      </div>
+      </TonalWidget>
 
       {groupedTransactions.length === 0 ? (
         <EmptyState
@@ -228,22 +309,17 @@ export function TransactionList({ transactions, accounts, categories }: Props) {
           {groupedTransactions.map((group) => (
             <section key={group.date} className="space-y-2">
               <div className="flex items-center justify-between px-1">
-                <h2 className="text-sm font-semibold tracking-tight">
-                  {group.label}
-                </h2>
+                <h2 className="text-sm font-semibold">{group.label}</h2>
                 <span className="text-xs text-muted-foreground">
                   {format(parseISO(group.date), "MMM d, yyyy")}
                 </span>
               </div>
 
-              <div className="overflow-hidden rounded-3xl border bg-card/85 shadow-sm shadow-foreground/5 backdrop-blur">
+              <TonalWidget tone="neutral" className="space-y-2 p-3 sm:p-3">
                 {group.items.map((transaction, index) => {
                   const Icon = getTransactionIcon(transaction.type);
                   const tone = getTransactionTone(transaction.type);
-                  const signedAmount =
-                    transaction.type === "expense"
-                      ? -Number(transaction.amount)
-                      : Number(transaction.amount);
+                  const signedAmount = getSignedAmount(transaction);
                   const account = accountMap.get(transaction.accountId);
                   const category = transaction.categoryId
                     ? categoryMap.get(transaction.categoryId)
@@ -253,29 +329,34 @@ export function TransactionList({ transactions, accounts, categories }: Props) {
                     <div
                       key={transaction.id}
                       className={cn(
-                        "group flex items-center justify-between gap-3 p-3 transition hover:bg-muted/40 sm:p-4",
-                        index > 0 && "border-t",
+                        "group flex items-center justify-between gap-3 rounded-[1.5rem] border bg-background/70 p-3 shadow-sm shadow-foreground/5 transition hover:bg-background sm:p-4",
+                        index === 0 && "border-primary/20",
                       )}
                     >
                       <div className="flex min-w-0 items-center gap-3">
-                        <div
-                          className={cn(
-                            "flex size-11 shrink-0 items-center justify-center rounded-2xl border",
-                            tone === "positive" &&
-                              "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
-                            tone === "negative" &&
-                              "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-300",
-                            tone === "info" &&
-                              "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300",
+                        <div className="relative">
+                          <IconBadge
+                            icon={Icon}
+                            tone={tone}
+                            className="size-12 rounded-[1.35rem]"
+                          />
+                          {category?.color && (
+                            <span
+                              className="absolute -bottom-1 -right-1 size-4 rounded-full border-2 border-background"
+                              style={{ backgroundColor: category.color }}
+                            />
                           )}
-                        >
-                          <Icon className="size-5" />
                         </div>
 
                         <div className="min-w-0">
-                          <p className="truncate text-sm font-semibold text-foreground">
-                            {transaction.note || "Untitled transaction"}
-                          </p>
+                          <div className="flex min-w-0 items-center gap-2">
+                            <p className="truncate text-sm font-semibold text-foreground">
+                              {transaction.note || "Untitled transaction"}
+                            </p>
+                            {!category && (
+                              <CircleDollarSign className="size-3.5 shrink-0 text-muted-foreground" />
+                            )}
+                          </div>
                           <div className="mt-1 flex flex-wrap items-center gap-2">
                             <StatusPill tone={tone}>
                               {transaction.type}
@@ -314,7 +395,7 @@ export function TransactionList({ transactions, accounts, categories }: Props) {
                     </div>
                   );
                 })}
-              </div>
+              </TonalWidget>
             </section>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- adds shared Cashew-inspired tonal widget primitives and amount boxes
- refreshes dashboard, transactions, budgets, goals, accounts, net worth, investments, loans, insurance, reports, import, and settings surfaces
- keeps changes UI-only with no schema changes or backend logic changes

## Validation
- bunx tsc --noEmit
- bun run lint
- bun run build