### PR TITLE
Fix Cashew UI font and dashboard density

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -149,13 +149,14 @@ export default async function DashboardPage() {
         }
         snapshot={<NetworthCard {...networthData} currency={baseCurrency} />}
         basics={
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-3 md:grid-cols-3">
             <MetricCard
               label="Accounts"
               value={accountList.length}
               description="Places where money lives: bank, wallet, cash, or savings."
               icon={WalletCards}
               tone={hasAccounts ? "positive" : "warning"}
+              className="rounded-[1.5rem]"
             />
             <MetricCard
               label="Categories"
@@ -163,6 +164,7 @@ export default async function DashboardPage() {
               description="Simple labels that make spending easier to understand."
               icon={Settings}
               tone={hasCategories ? "positive" : "warning"}
+              className="rounded-[1.5rem]"
             />
             <MetricCard
               label="Recent entries"
@@ -170,6 +172,7 @@ export default async function DashboardPage() {
               description="Latest activity captured in your private ledger."
               icon={ReceiptText}
               tone={hasTransactions ? "positive" : "neutral"}
+              className="rounded-[1.5rem]"
             />
           </div>
         }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -18,7 +18,7 @@ export default async function AppLayout({
 
       {/* Main content — add bottom padding on mobile for bottom nav */}
       <main className="min-w-0 flex-1 overflow-y-auto pb-24 md:pb-0">
-        <div className="min-h-screen bg-background/45">{children}</div>
+        <div className="min-h-screen bg-background/70">{children}</div>
       </main>
 
       {/* Mobile bottom nav */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
     --color-background: var(--background);
     --color-foreground: var(--foreground);
-    --font-sans: var(--font-sans);
+    --font-sans: var(--font-geist-sans);
     --font-mono: var(--font-geist-mono);
     --font-display: var(--font-manrope);
     --font-heading: var(--font-manrope);
@@ -210,6 +210,7 @@
     }
     html {
         @apply font-sans;
+        font-family: var(--font-geist-sans), system-ui, sans-serif;
         font-feature-settings: "cv02", "cv03", "cv04", "cv11";
         text-rendering: optimizeLegibility;
     }
@@ -240,13 +241,18 @@
     :where(.tabular-nums, [data-financial-value]) {
         font-variant-numeric: tabular-nums;
     }
+    :where(body, button, input, textarea, select) {
+        font-family: var(--font-geist-sans), system-ui, sans-serif;
+    }
     :where(h1, h2, h3, .font-heading, .font-display, [data-display-text]) {
-        font-family: var(--font-display), var(--font-sans), system-ui, sans-serif;
+        font-family: var(--font-manrope), var(--font-geist-sans), system-ui, sans-serif;
+        letter-spacing: 0;
     }
     :where([data-financial-value], .financial-display) {
-        font-family: var(--font-display), var(--font-sans), system-ui, sans-serif;
+        font-family: var(--font-manrope), var(--font-geist-sans), system-ui, sans-serif;
         font-variant-numeric: tabular-nums;
         line-height: 1.05;
+        letter-spacing: 0;
     }
     ::selection {
         background: color-mix(in oklch, var(--primary) 24%, transparent);

--- a/src/components/dashboard/DashboardSections.tsx
+++ b/src/components/dashboard/DashboardSections.tsx
@@ -74,10 +74,10 @@ export function DashboardSections({
   const hiddenCount = sectionLabels.filter((item) => !visibility[item.key]).length
 
   return (
-    <div className="space-y-6">
-      <div className="rounded-3xl border bg-card/70 p-3 shadow-sm shadow-foreground/5">
+    <div className="space-y-5">
+      <div className="rounded-[1.5rem] border bg-card/80 p-2.5 shadow-sm shadow-foreground/5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2 text-sm font-semibold">
+          <div className="flex items-center gap-2 px-1 text-sm font-semibold">
             <SlidersHorizontal className="size-4 text-primary" />
             Home sections
           </div>
@@ -94,7 +94,7 @@ export function DashboardSections({
                   className={cn(
                     'inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-2 text-xs font-semibold transition',
                     active
-                      ? 'border-primary/20 bg-primary/10 text-primary'
+                      ? 'border-primary/20 bg-primary text-primary-foreground shadow-sm'
                       : 'border-border bg-background/70 text-muted-foreground hover:bg-muted'
                   )}
                 >
@@ -121,14 +121,16 @@ export function DashboardSections({
       </div>
 
       {visibility.setup && setup}
-      {visibility.snapshot && snapshot}
-      {visibility.basics && basics}
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(22rem,0.9fr)]">
-        <div className="space-y-6">
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(22rem,0.8fr)]">
+        <div className="space-y-5">
+          {visibility.snapshot && snapshot}
+          {visibility.basics && basics}
           {visibility.cashFlow && cashFlow}
+        </div>
+        <div className="space-y-5">
+          {visibility.attention && attention}
           {visibility.recent && recent}
         </div>
-        {visibility.attention && attention}
       </div>
     </div>
   )

--- a/src/components/dashboard/NetworthCard.tsx
+++ b/src/components/dashboard/NetworthCard.tsx
@@ -36,7 +36,7 @@ export function NetworthCard({
     networth > 0 ? "positive" : networth < 0 ? "negative" : "neutral";
 
   return (
-    <TonalWidget tone="primary" className="space-y-6">
+    <TonalWidget tone="primary" className="space-y-5">
       <WidgetHeading
         icon={PiggyBank}
         tone="primary"
@@ -54,11 +54,11 @@ export function NetworthCard({
         }
       />
 
-      <div className="rounded-[1.75rem] border bg-background/75 p-5 shadow-sm shadow-foreground/5 sm:p-6">
+      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5 sm:p-5">
         <p className="text-sm font-medium text-muted-foreground">
           Family balance
         </p>
-        <h2 className="financial-display mt-2 text-4xl font-bold text-foreground sm:text-5xl">
+        <h2 className="financial-display mt-2 text-3xl font-extrabold text-foreground sm:text-4xl">
           <FinancialAmount amount={networth} currency={currency} />
         </h2>
         <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
@@ -67,7 +67,7 @@ export function NetworthCard({
         </p>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid gap-3 lg:grid-cols-3">
         <div className="space-y-3">
           <AmountBox
             label="Cash"

--- a/src/components/shared/Sidebar.tsx
+++ b/src/components/shared/Sidebar.tsx
@@ -61,17 +61,17 @@ export function Sidebar({ className }: { className?: string }) {
   return (
     <aside
       className={cn(
-        "sticky top-0 h-screen w-64 shrink-0 border-r border-sidebar-border bg-sidebar/90 text-sidebar-foreground backdrop-blur flex flex-col",
+        "sticky top-0 flex h-screen w-60 shrink-0 flex-col border-r border-sidebar-border bg-sidebar/95 text-sidebar-foreground backdrop-blur",
         className,
       )}
     >
-      <div className="border-b border-sidebar-border px-4 py-5">
+      <div className="border-b border-sidebar-border px-4 py-4">
         <div className="flex items-center gap-3">
-          <div className="flex size-10 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
+          <div className="flex size-9 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
             <PiggyBank className="size-5" />
           </div>
           <div className="min-w-0">
-            <span className="block text-lg font-bold tracking-tight">
+            <span className="block text-base font-bold">
               Ledgerify
             </span>
             <span className="block text-xs text-muted-foreground">
@@ -81,7 +81,7 @@ export function Sidebar({ className }: { className?: string }) {
         </div>
       </div>
 
-      <div className="px-3 py-4">
+      <div className="px-3 py-3">
         <Link
           href="/transactions"
           className="flex items-center justify-center gap-2 rounded-2xl bg-primary px-3 py-2.5 text-sm font-semibold text-primary-foreground shadow-sm transition hover:bg-primary/90"
@@ -92,7 +92,7 @@ export function Sidebar({ className }: { className?: string }) {
       </div>
 
       <nav className="flex-1 overflow-y-auto px-3 pb-4">
-        <div className="space-y-5">
+        <div className="space-y-4">
           {navSections.map((section) => (
             <div key={section.label} className="space-y-1.5">
               <p className="px-3 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -109,7 +109,7 @@ export function Sidebar({ className }: { className?: string }) {
                       key={item.href}
                       href={item.href}
                       className={cn(
-                        "group flex items-center gap-3 rounded-2xl px-3 py-2.5 text-sm font-medium transition-colors",
+                        "group flex items-center gap-3 rounded-2xl px-3 py-2 text-sm font-medium transition-colors",
                         active
                           ? "bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
                           : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",

--- a/src/components/shared/quiet-ledger.tsx
+++ b/src/components/shared/quiet-ledger.tsx
@@ -136,10 +136,10 @@ export function PageShell({
   return (
     <div
       className={cn(
-        'mx-auto flex w-full flex-col gap-6 px-4 py-5 sm:px-6 lg:px-8 lg:py-8',
+        'flex w-full flex-col gap-5 px-4 py-4 sm:px-5 lg:px-6 lg:py-6',
         size === 'narrow' && 'max-w-3xl',
         size === 'default' && 'max-w-6xl',
-        size === 'wide' && 'max-w-7xl',
+        size === 'wide' && 'max-w-none',
         className
       )}
     >
@@ -166,7 +166,7 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        'flex flex-col gap-4 rounded-3xl border bg-card/80 p-5 shadow-sm shadow-foreground/5 backdrop-blur sm:p-6 lg:flex-row lg:items-end lg:justify-between',
+        'flex flex-col gap-4 rounded-[1.75rem] border bg-card/90 p-4 shadow-sm shadow-foreground/5 backdrop-blur sm:p-5 lg:flex-row lg:items-end lg:justify-between',
         className
       )}
     >
@@ -179,12 +179,12 @@ export function PageHeader({
         <div className="space-y-1">
           <h1
             data-display-text
-            className="text-2xl font-bold text-foreground sm:text-3xl"
+            className="text-2xl font-extrabold text-foreground sm:text-[2rem]"
           >
             {title}
           </h1>
           {description && (
-            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
               {description}
             </p>
           )}
@@ -360,7 +360,7 @@ export function TonalWidget({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-[2rem] border p-5 shadow-sm shadow-foreground/5 sm:p-6',
+        'relative overflow-hidden rounded-[1.75rem] border p-4 shadow-sm shadow-foreground/5 sm:p-5',
         toneStyles[tone].bg,
         toneStyles[tone].border,
         className
@@ -651,14 +651,14 @@ export function SetupChecklist({
   }
 
   return (
-    <Card className={cn('rounded-3xl bg-card/85 shadow-sm ring-0', className)}>
-      <CardHeader>
-        <CardTitle>Finish your money home</CardTitle>
+    <Card className={cn('rounded-[1.75rem] bg-card/90 shadow-sm ring-0', className)}>
+      <CardHeader className="px-4 py-4">
+        <CardTitle className="text-base">Finish your money home</CardTitle>
         <CardDescription>
           A few basics make Ledgerify easier to use every day.
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2">
+      <CardContent className="grid gap-2 px-4 pb-4 md:grid-cols-3">
         {items.map((item) => (
           <Link
             key={item.href}


### PR DESCRIPTION
## Summary
- fixes the broken Tailwind font token that caused serif fallback instead of Geist/Manrope
- tightens the app shell, sidebar, and wide page layout so desktop no longer renders like a centered document
- compacts dashboard setup and net-worth surfaces for a more app-like first viewport

## Validation
- bunx tsc --noEmit
- bun run lint
- bun run build