### PR TITLE
feat: add /api/v1 REST layer for agent access

### DIFF
--- a/docs/plans/2026-04-30-cashew-visual-rework-v2-design.md
+++ b/docs/plans/2026-04-30-cashew-visual-rework-v2-design.md
@@ -1,0 +1,251 @@
+# Cashew Visual Rework v2 — Design
+
+**Date:** 2026-04-30
+**Branch:** `feat/cashew-visual-rework-v2`
+**Scope:** Full UI rework across all app surfaces plus one schema ease-of-life change. No backend domain logic changes.
+
+---
+
+## 1. Context
+
+PR #3 shipped Quiet Ledger foundations: design tokens, shared primitives in `quiet-ledger.tsx`, Manrope typography, appearance settings, and transaction toolbar basics. The plan doc `2026-04-29-cashew-inspired-ui-font-plan.md` explicitly flags the next step as Cashew Visual Rework v2 — making the visible app feel meaningfully different, not just adding settings infrastructure.
+
+This document is the approved design for that rework.
+
+---
+
+## 2. Approach
+
+One PR — schema change plus all UI segments together. The schema change is small (one column), and having it land with the UI that uses it is cleaner than a gap between PRs.
+
+---
+
+## 3. Schema Change
+
+### 3.1 `accounts.currentBalance`
+
+Add `current_balance NUMERIC DEFAULT 0 NOT NULL` to the `accounts` table.
+
+**Migration:** New Drizzle migration file. No existing data is lost. Existing accounts start at `0` — users can set an opening balance or it will self-correct as transactions are entered.
+
+**Maintenance:** All transaction server actions (`createTransaction`, `updateTransaction`, `deleteTransaction`) must update the affected account's `currentBalance` atomically in the same DB call:
+- Income: `currentBalance += amount`
+- Expense: `currentBalance -= amount`
+- Transfer: source `currentBalance -= amount`, destination `currentBalance += amount`
+- Update: reverse old effect, apply new effect
+- Delete: reverse the effect
+
+**Simplification:** `computeNetworth` removes the per-account transaction sum SQL and uses `account.currentBalance` directly. This eliminates N+1 queries per account.
+
+---
+
+## 4. Dashboard Widgets
+
+### 4.1 Balance Snapshot Widget
+
+Replaces current `NetworthCard`. Uses `primary` tonal background.
+
+Content:
+- Small eyebrow: "Your money home"
+- Large hero number: net worth in Manrope 48–56px bold
+- Asset/liability chip strip below: Cash | Investments | Liabilities as colored tonal chips (`cash` sky, `investment` violet, `loan` orange)
+- Quick-link row: Overview → Accounts → Investments → Loans
+
+### 4.2 Daily Money Widget
+
+Replaces current `CashFlowSummary`. Uses `cash` tonal background.
+
+Content:
+- 3 compact `AmountBox` tiles: Income / Expenses / Net
+- Plain-language status line derived from net: "Spending is below income this month" / "Expenses are ahead this month" / "Balanced"
+- Month progress bar (days elapsed / total days)
+- Expense pace vs income (existing)
+- Transaction count
+
+### 4.3 Quick Add Strip
+
+New. Sits between the hero snapshot and the planning widgets on the dashboard.
+
+Content:
+- 3 pill/tile action buttons: `+ Expense` (rose), `+ Income` (emerald), `+ Transfer` (sky)
+- Each links to `/transactions?type=expense` etc. using existing query-param defaulting on `TransactionForm`
+
+### 4.4 Planning Widgets
+
+New. Requires adding budget + savings goal queries to the dashboard server component loader.
+
+**Budget Health Tile:**
+- Total budgets count
+- Safe / At-risk / Over counts with colored chips
+- Overall spend vs total budget limits as a progress bar
+
+**Goal Progress Tile:**
+- Total saved across all goals vs total target
+- Percentage ring
+- Goals count and active deadline count
+
+### 4.5 Protection & Debt Widget
+
+Replaces/extends current `UpcomingAlerts`. Uses `insurance` indigo tonal background.
+
+Content:
+- Loan EMIs and insurance renewals in a unified attention list
+- Denser Cashew-style rows: domain icon → name + description → due-date countdown pill → amount
+- No structural change to data loading
+
+### 4.6 Recent Activity
+
+Replaces current `RecentTransactions`.
+
+Content:
+- Category/account glyph (colored tonal square, first letter of category or transaction type initial)
+- Row layout: glyph → note (primary) + category·account (secondary) → date → signed amount
+- No visible delete on dashboard surface
+- "View all" link preserved
+
+### 4.7 DashboardSections
+
+Add `planning` slot alongside existing slots. Visibility toggle gains "Planning" section button. Section ordering: setup → snapshot → quickAdd → cashFlow → planning → attention → recent.
+
+---
+
+## 5. Transactions
+
+### 5.1 Summary Strip
+
+New. Above the transaction list, show 3 compact `AmountBox` tiles: Income / Expenses / Net computed client-side from the currently visible (filtered) transaction set.
+
+### 5.2 Segmented Control
+
+Replace current type filter chips with a Material-style segmented selector: `All | Income | Expenses | Transfers`. Active segment has filled tonal background.
+
+### 5.3 Category/Account Glyph
+
+Each transaction row gets a colored tonal square: first letter of category name if available, else transaction type initial. Color driven by transaction type tone (`positive` for income, `negative` for expense, `info` for transfer).
+
+### 5.4 Row Layout
+
+Order: glyph → note (primary) + category·account (secondary) → date·tags → signed amount.
+
+Delete moved to overflow `⋯` menu. No visible destructive action in normal list view.
+
+### 5.5 Empty State
+
+3 action tiles: *Add expense*, *Add income*, *Import CSV*.
+
+---
+
+## 6. Budgets & Goals
+
+### 6.1 Budget Cards
+
+Progress-first surface:
+- Budget name + category name
+- Period badge (Monthly / Weekly)
+- Spent / Limit as large fraction
+- Colored progress bar: emerald (< 70%), amber (70–99%), rose (≥ 100%)
+- Status badge: Safe / Watch / Over
+- Days remaining in period
+
+### 6.2 Budgets Page Header
+
+Health summary strip:
+- Total budget count
+- Safe / Watch / Over counts as tonal chips
+- Total spent vs total budget
+
+### 6.3 Goal Cards
+
+Progress-first motivating surface:
+- Goal name + deadline
+- Current / Target as large fraction
+- Percentage progress bar (teal)
+- Deadline pressure label: "X days left" or "Achieved"
+- Contribute action button
+
+---
+
+## 7. Wealth & Obligations
+
+### 7.1 Investments Page
+
+Add portfolio summary widget at top (`investment` violet tonal):
+- Total current value
+- Total cost basis
+- Unrealized P&L (amount + percentage, signed color)
+- Asset-type allocation chips
+
+Asset cards: domain-colored violet tonal treatment, P&L badges.
+
+### 7.2 Loans Page
+
+Add debt summary widget at top (`loan` orange tonal):
+- Total outstanding balance
+- Monthly EMI total
+- Active loan count
+
+Loan cards: payoff progress bar, months remaining label.
+
+### 7.3 Insurance Page
+
+Add coverage summary widget at top (`insurance` indigo tonal):
+- Total coverage amount
+- Annual premium total
+- Next renewal countdown
+
+Policy cards: indigo tonal treatment, renewal urgency states.
+
+---
+
+## 8. Reports
+
+### 8.1 Summary Cards Strip
+
+Each report page gets a 3-card summary strip above the chart showing the most useful derived stats (e.g., cash flow: avg monthly income, avg monthly expenses, net trend).
+
+### 8.2 Chart Standards
+
+- Softer grid lines (`stroke-muted-foreground/20`)
+- Rounded bars (`radius={4}`)
+- Semantic tooltip colors matching Quiet Ledger tones
+- Consistent chart container height (300px mobile, 380px desktop)
+- Each report gets one derived plain-language insight sentence
+
+### 8.3 Reports Index
+
+Replace card grid with featured insight tiles, each showing a key stat from the underlying data.
+
+---
+
+## 9. Import Page
+
+Restructure as 3-step guided flow:
+1. **Choose file** — drag-drop zone + file picker, template download link
+2. **Review columns** — visual checklist of required CSV columns with check/cross per column detected in the file
+3. **Import** — progress indicator during parse, success/error summary
+
+No backend changes to `/api/import` route.
+
+---
+
+## 10. Constraints
+
+- No additional schema changes beyond `accounts.currentBalance`
+- No backend domain logic changes
+- No new DB tables
+- All filtering/computation that can run client-side stays client-side
+- Validation must pass: `bunx tsc --noEmit`, `bun run lint`, `bun run build`
+
+---
+
+## 11. Success Criteria
+
+- Dashboard looks visibly Cashew-inspired at first glance: large tonal widgets, not a metrics grid
+- Transaction list has glyph icons, segmented control, summary strip
+- Budget and goal cards are progress-first
+- Investment, loan, insurance pages have domain-colored summary widgets
+- Reports have chart-standard containers and insight copy
+- Import has guided flow
+- All pages pass the UX Quality Checklist from `2026-04-29-ux-ui-refresh.md`
+- No schema migrations other than `accounts.currentBalance`
+- CI passes: typecheck + lint + build

--- a/docs/plans/2026-04-30-cashew-visual-rework-v2-plan.md
+++ b/docs/plans/2026-04-30-cashew-visual-rework-v2-plan.md
@@ -1,0 +1,1194 @@
+# Cashew Visual Rework v2 — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Transform every app surface into a Cashew-inspired widget-style UI while adding `accounts.currentBalance` for fast balance reads.
+
+**Architecture:** One PR on branch `feat/cashew-visual-rework-v2`. Schema first, then dashboard, transactions, planning, wealth/obligations, reports, import. Each task is a focused Edit followed by a verify+commit. No backend domain logic changes. No extra DB tables.
+
+**Tech Stack:** Next.js 16 App Router, Drizzle ORM, Tailwind v4, shadcn/ui base-ui, Recharts, Bun, Zod v4, Auth.js v5
+
+**Key rules:**
+- Use `Edit` tool in small chunks — never rewrite whole files at once
+- Run `bunx tsc --noEmit && bun run lint` after every task
+- Run `bun run build` after every segment (tasks grouped below)
+- All money stored as strings in DB, cast with `Number()` when computing
+- shadcn uses base-ui render prop: `<SheetTrigger render={<Button />}>`
+- `formatCurrency` → `src/lib/utils/format.ts` (client-safe)
+- `getRate` → `src/lib/utils/currency.ts` (server-only)
+
+## Segment 2: Dashboard Widgets
+
+### Task 4: Extend dashboard loader + add QuickAddStrip component
+
+**Files:**
+- Modify: `src/app/(app)/dashboard/page.tsx`
+- Create: `src/components/dashboard/QuickAddStrip.tsx`
+
+**Step 1: Add budget + savings goal queries to dashboard loader**
+
+In `src/app/(app)/dashboard/page.tsx`, add imports:
+
+```ts
+import { budgets, savingsGoals } from "@/lib/db/schema";
+import { startOfMonth, endOfMonth, startOfWeek, endOfWeek } from "date-fns";
+```
+
+Add to the `Promise.all` array:
+
+```ts
+// budgets
+db.select().from(budgets).where(and(eq(budgets.userId, userId), isNull(budgets.deletedAt))),
+// savings goals
+db.select().from(savingsGoals).where(and(eq(savingsGoals.userId, userId), isNull(savingsGoals.deletedAt))),
+// monthly expenses (for budget progress)
+db.select().from(transactions).where(and(
+  eq(transactions.userId, userId),
+  eq(transactions.type, 'expense'),
+  isNull(transactions.deletedAt),
+  gte(transactions.date, monthStart),
+  lte(transactions.date, monthEnd),
+)),
+```
+
+Destructure the new entries from the result array.
+
+**Step 2: Create `QuickAddStrip` component**
+
+Create `src/components/dashboard/QuickAddStrip.tsx`:
+
+```tsx
+import Link from "next/link"
+import { ArrowDownLeft, ArrowLeftRight, ArrowUpRight } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const actions = [
+  { label: "Expense", href: "/transactions?type=expense", icon: ArrowDownLeft, color: "bg-rose-50 text-rose-700 border-rose-200/80 hover:bg-rose-100 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900" },
+  { label: "Income",  href: "/transactions?type=income",  icon: ArrowUpRight,  color: "bg-emerald-50 text-emerald-700 border-emerald-200/80 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900" },
+  { label: "Transfer",href: "/transactions?type=transfer",icon: ArrowLeftRight, color: "bg-sky-50 text-sky-700 border-sky-200/80 hover:bg-sky-100 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-900" },
+]
+
+export function QuickAddStrip() {
+  return (
+    <div className="flex gap-3">
+      {actions.map(({ label, href, icon: Icon, color }) => (
+        <Link
+          key={label}
+          href={href}
+          className={cn(
+            "flex flex-1 items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-sm font-semibold transition",
+            color,
+          )}
+        >
+          <Icon className="size-4" />
+          {label}
+        </Link>
+      ))}
+    </div>
+  )
+}
+```
+
+**Step 3: Add `QuickAddStrip` import + usage in dashboard page**
+
+In `src/app/(app)/dashboard/page.tsx`, import and pass it as a new `quickAdd` prop to `DashboardSections`.
+
+**Step 4: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/(app)/dashboard/page.tsx src/components/dashboard/QuickAddStrip.tsx
+git commit -m "feat(dashboard): extend loader with budgets/goals, add QuickAddStrip"
+```
+
+---
+
+### Task 5: Build `BalanceSnapshotWidget` (replaces `NetworthCard`)
+
+**Files:**
+- Modify: `src/components/dashboard/NetworthCard.tsx`
+
+**Step 1: Rewrite `NetworthCard` to widget style**
+
+Replace the entire component body with:
+
+```tsx
+"use client"
+import Link from "next/link"
+import { Landmark, PiggyBank, TrendingUp, WalletCards } from "lucide-react"
+import type { NetworthData } from "@/lib/utils/networth"
+import { FinancialAmount, IconBadge, ProgressMeter, StatusPill, TonalWidget, WidgetHeading } from "@/components/shared/quiet-ledger"
+import { cn } from "@/lib/utils"
+
+interface Props extends NetworthData { currency: string }
+
+const quickLinks = [
+  { label: "Net Worth",    href: "/networth",     icon: PiggyBank  },
+  { label: "Investments",  href: "/investments",  icon: TrendingUp },
+  { label: "Loans",        href: "/loans",        icon: Landmark   },
+  { label: "Accounts",     href: "/settings/accounts", icon: WalletCards },
+]
+
+export function NetworthCard({ networth, totalCash, totalInvestments, totalLiabilities, currency }: Props) {
+  const totalAssets = totalCash + totalInvestments
+  const safe = Math.max(totalAssets, 1)
+  const cashPct = Math.min((totalCash / safe) * 100, 100)
+  const invPct  = Math.min((totalInvestments / safe) * 100, 100)
+  const liabRatio = totalAssets > 0 ? totalLiabilities / totalAssets : 0
+  const tone = networth > 0 ? "positive" : networth < 0 ? "negative" : "neutral"
+
+  return (
+    <TonalWidget tone="primary" className="space-y-5">
+      <WidgetHeading
+        icon={PiggyBank} tone="primary"
+        eyebrow="Balance snapshot"
+        title="Net worth"
+        description="Assets minus liabilities."
+        action={<StatusPill tone={tone}>{networth > 0 ? "Positive" : networth < 0 ? "Deficit" : "Starting out"}</StatusPill>}
+      />
+
+      {/* Hero number */}
+      <div className="rounded-3xl border bg-background/75 px-5 py-4 shadow-sm shadow-foreground/5">
+        <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Total net worth</p>
+        <p className="financial-display mt-1 text-4xl font-extrabold sm:text-5xl">
+          <FinancialAmount amount={networth} currency={currency} />
+        </p>
+      </div>
+
+      {/* Asset chips */}
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { label: "Cash", amount: totalCash, pct: cashPct, tone: "cash" as const, icon: WalletCards },
+          { label: "Investments", amount: totalInvestments, pct: invPct, tone: "investment" as const, icon: TrendingUp },
+          { label: "Liabilities", amount: totalLiabilities, pct: Math.min(liabRatio * 100, 100), tone: liabRatio > 0.5 ? "negative" as const : "loan" as const, icon: Landmark },
+        ].map(({ label, amount, pct, tone: t, icon: Icon }) => (
+          <div key={label} className="space-y-2 rounded-2xl border bg-background/60 p-3">
+            <IconBadge icon={Icon} tone={t} className="size-8 rounded-xl" />
+            <p className="text-xs text-muted-foreground">{label}</p>
+            <p className="text-sm font-bold tabular-nums"><FinancialAmount amount={amount} currency={currency} /></p>
+            <ProgressMeter value={pct} tone={t} label="" />
+          </div>
+        ))}
+      </div>
+
+      {/* Quick links */}
+      <div className="flex flex-wrap gap-2">
+        {quickLinks.map(({ label, href, icon: Icon }) => (
+          <Link key={href} href={href} className="flex items-center gap-1.5 rounded-full border bg-background/60 px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-background hover:text-foreground">
+            <Icon className="size-3.5" />
+            {label}
+          </Link>
+        ))}
+      </div>
+    </TonalWidget>
+  )
+}
+```
+
+**Step 2: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/components/dashboard/NetworthCard.tsx
+git commit -m "feat(dashboard): BalanceSnapshotWidget with hero number + asset chips"
+```
+
+---
+
+### Task 6: Build `DailyMoneyWidget` (replaces `CashFlowSummary`)
+
+**Files:**
+- Modify: `src/components/dashboard/CashFlowSummary.tsx`
+
+**Step 1: Rewrite `CashFlowSummary` with month progress + insight copy**
+
+Key additions vs current: month progress bar, plain-language insight sentence, compact layout.
+
+```tsx
+"use client"
+import { getDaysInMonth } from "date-fns"
+import { ArrowDownLeft, ArrowLeftRight, ArrowUpRight, WalletCards } from "lucide-react"
+import type { Transaction } from "@/lib/db/schema"
+import { AmountBox, ProgressMeter, StatusPill, TonalWidget, WidgetHeading } from "@/components/shared/quiet-ledger"
+
+interface Props { transactions: Transaction[]; currency: string }
+
+export function CashFlowSummary({ transactions, currency }: Props) {
+  const income  = transactions.filter(t => t.type === "income" ).reduce((s, t) => s + Number(t.convertedAmount ?? t.amount), 0)
+  const expense = transactions.filter(t => t.type === "expense").reduce((s, t) => s + Number(t.convertedAmount ?? t.amount), 0)
+  const net = income - expense
+  const expensePace = income > 0 ? Math.min((expense / income) * 100, 100) : 0
+  const netTone = net > 0 ? "positive" : net < 0 ? "negative" : "neutral"
+
+  // Month progress
+  const now = new Date()
+  const dayOfMonth = now.getDate()
+  const daysInMonth = getDaysInMonth(now)
+  const monthProgress = Math.round((dayOfMonth / daysInMonth) * 100)
+
+  // Insight
+  const insight = income === 0
+    ? "Add income transactions to track your monthly cash flow."
+    : net > 0
+      ? `Spending is below income this month — ${Math.round(expensePace)}% of income spent so far.`
+      : `Expenses are ahead of income this month by ${Math.abs(Math.round(net)).toLocaleString()} ${currency}.`
+
+  return (
+    <TonalWidget tone="cash" className="space-y-5">
+      <WidgetHeading
+        icon={WalletCards} tone="cash"
+        eyebrow="Month in motion"
+        title="Cash flow"
+        description={insight}
+        action={<StatusPill tone={netTone}>{net > 0 ? "Ahead" : net < 0 ? "Behind" : "Balanced"}</StatusPill>}
+      />
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <AmountBox label="Income"   amount={income}   currency={currency} icon={ArrowUpRight}  tone="positive" count="Received this month" />
+        <AmountBox label="Expenses" amount={expense}  currency={currency} icon={ArrowDownLeft} tone="negative" count="Spent this month" />
+        <AmountBox label="Net"      amount={net}      currency={currency} icon={ArrowLeftRight} tone={netTone} sign="always" count="Income minus expenses" />
+      </div>
+
+      <div className="space-y-3 rounded-3xl border bg-background/70 p-4">
+        <ProgressMeter value={expensePace} tone={expensePace > 85 ? "warning" : "positive"} label="Expense pace vs income" />
+        <ProgressMeter value={monthProgress} tone="info" label={`Month progress — day ${dayOfMonth} of ${daysInMonth}`} />
+      </div>
+    </TonalWidget>
+  )
+}
+```
+
+**Step 2: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/components/dashboard/CashFlowSummary.tsx
+git commit -m "feat(dashboard): DailyMoneyWidget with month progress + insight copy"
+```
+
+---
+
+### Task 7: Build `PlanningWidgets` component
+
+**Files:**
+- Create: `src/components/dashboard/PlanningWidgets.tsx`
+
+**Step 1: Create the component**
+
+```tsx
+"use client"
+import Link from "next/link"
+import { Target, Wallet } from "lucide-react"
+import type { Budget, SavingsGoal, Transaction } from "@/lib/db/schema"
+import { AmountBox, FinancialAmount, IconBadge, ProgressMeter, StatusPill, TonalWidget, WidgetHeading } from "@/components/shared/quiet-ledger"
+
+interface Props {
+  budgets: Budget[]
+  goals: SavingsGoal[]
+  monthlyExpenses: Transaction[]
+  currency: string
+}
+
+export function PlanningWidgets({ budgets, goals, monthlyExpenses, currency }: Props) {
+  // Budget health
+  const budgetProgress = budgets.map(b => {
+    const relevant = b.categoryId
+      ? monthlyExpenses.filter(t => t.categoryId === b.categoryId)
+      : monthlyExpenses
+    const spent = relevant.reduce((s, t) => s + Number(t.convertedAmount ?? t.amount), 0)
+    const limit = Number(b.amount)
+    const pct = limit > 0 ? (spent / limit) * 100 : 0
+    return { ...b, spent, limit, pct }
+  })
+  const totalBudgetLimit = budgetProgress.reduce((s, b) => s + b.limit, 0)
+  const totalBudgetSpent = budgetProgress.reduce((s, b) => s + b.spent, 0)
+  const overCount  = budgetProgress.filter(b => b.pct >= 100).length
+  const watchCount = budgetProgress.filter(b => b.pct >= 70 && b.pct < 100).length
+  const safeCount  = budgetProgress.filter(b => b.pct < 70).length
+  const overallBudgetPct = totalBudgetLimit > 0 ? Math.min((totalBudgetSpent / totalBudgetLimit) * 100, 100) : 0
+
+  // Goals health
+  const totalGoalTarget  = goals.reduce((s, g) => s + Number(g.targetAmount), 0)
+  const totalGoalCurrent = goals.reduce((s, g) => s + Number(g.currentAmount ?? 0), 0)
+  const goalPct = totalGoalTarget > 0 ? Math.min((totalGoalCurrent / totalGoalTarget) * 100, 100) : 0
+  const achievedCount = goals.filter(g => Number(g.currentAmount ?? 0) >= Number(g.targetAmount)).length
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {/* Budget health tile */}
+      <TonalWidget tone="budget" className="space-y-4">
+        <WidgetHeading icon={Wallet} tone="budget" eyebrow="Planning" title="Budget health" />
+        {budgets.length === 0 ? (
+          <Link href="/budgets" className="block text-sm text-muted-foreground hover:underline">Set up your first budget →</Link>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2">
+              {safeCount  > 0 && <StatusPill tone="positive">{safeCount} safe</StatusPill>}
+              {watchCount > 0 && <StatusPill tone="warning">{watchCount} watch</StatusPill>}
+              {overCount  > 0 && <StatusPill tone="negative">{overCount} over</StatusPill>}
+            </div>
+            <ProgressMeter value={overallBudgetPct} tone={overCount > 0 ? "negative" : watchCount > 0 ? "warning" : "positive"} label="Total spent vs budget" />
+            <p className="text-xs text-muted-foreground">
+              <FinancialAmount amount={totalBudgetSpent} currency={currency} /> of{" "}
+              <FinancialAmount amount={totalBudgetLimit} currency={currency} /> budgeted
+            </p>
+          </>
+        )}
+      </TonalWidget>
+
+      {/* Goal progress tile */}
+      <TonalWidget tone="goal" className="space-y-4">
+        <WidgetHeading icon={Target} tone="goal" eyebrow="Planning" title="Savings goals" />
+        {goals.length === 0 ? (
+          <Link href="/budgets/goals" className="block text-sm text-muted-foreground hover:underline">Set up your first goal →</Link>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2">
+              <StatusPill tone="neutral">{goals.length} goal{goals.length !== 1 ? "s" : ""}</StatusPill>
+              {achievedCount > 0 && <StatusPill tone="positive">{achievedCount} achieved</StatusPill>}
+            </div>
+            <ProgressMeter value={goalPct} tone="goal" label="Overall progress" />
+            <p className="text-xs text-muted-foreground">
+              <FinancialAmount amount={totalGoalCurrent} currency={currency} /> of{" "}
+              <FinancialAmount amount={totalGoalTarget} currency={currency} /> saved
+            </p>
+          </>
+        )}
+      </TonalWidget>
+    </div>
+  )
+}
+```
+
+**Step 2: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/components/dashboard/PlanningWidgets.tsx
+git commit -m "feat(dashboard): PlanningWidgets — budget health + goal progress tiles"
+```
+
+---
+
+### Task 8: Add `planning` slot to `DashboardSections` + wire everything in dashboard page
+
+**Files:**
+- Modify: `src/components/dashboard/DashboardSections.tsx`
+- Modify: `src/app/(app)/dashboard/page.tsx`
+
+**Step 1: Add `planning` and `quickAdd` to `DashboardSections`**
+
+- Add `planning` and `quickAdd` to `defaultVisibility`, `sectionLabels`, and the props interface.
+- Add `{visibility.quickAdd && quickAdd}` between setup and snapshot.
+- Add `{visibility.planning && planning}` between cashFlow and attention.
+
+**Step 2: Update dashboard page to import and pass new components**
+
+Import `QuickAddStrip` and `PlanningWidgets`. Pass them:
+
+```tsx
+<DashboardSections
+  setup={...}
+  snapshot={<NetworthCard {...networthData} currency={baseCurrency} />}
+  quickAdd={<QuickAddStrip />}
+  basics={...}
+  cashFlow={<CashFlowSummary transactions={monthlyTxs} currency={baseCurrency} />}
+  planning={<PlanningWidgets budgets={budgetList} goals={goalList} monthlyExpenses={monthlyExpenses} currency={baseCurrency} />}
+  recent={<RecentTransactions transactions={recentTxs} />}
+  attention={<UpcomingAlerts loans={loanList} policies={policyList} />}
+/>
+```
+
+**Step 3: Build verify**
+
+```bash
+bunx tsc --noEmit && bun run lint && bun run build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/components/dashboard/DashboardSections.tsx src/app/(app)/dashboard/page.tsx
+git commit -m "feat(dashboard): wire QuickAddStrip + PlanningWidgets into DashboardSections"
+```
+
+---
+
+---
+
+## Segment 1: Schema + Networth
+
+### Task 1: Add `currentBalance` to accounts schema
+
+**Files:**
+- Modify: `src/lib/db/schema/accounts.ts`
+- Create: `drizzle/0001_accounts_current_balance.sql`
+
+**Step 1: Add column to Drizzle schema**
+
+In `src/lib/db/schema/accounts.ts`, add import for `numeric` and add the column:
+
+```ts
+import { pgTable, uuid, varchar, timestamp, pgEnum, numeric } from 'drizzle-orm/pg-core'
+// ...existing code...
+export const accounts = pgTable('accounts', {
+  // ...existing columns...
+  currentBalance: numeric('current_balance').notNull().default('0'),
+})
+```
+
+**Step 2: Write the migration SQL**
+
+Create `drizzle/0001_accounts_current_balance.sql`:
+
+```sql
+ALTER TABLE "accounts" ADD COLUMN "current_balance" numeric NOT NULL DEFAULT 0;
+```
+
+**Step 3: Apply migration on VPS**
+
+```bash
+# locally — verify schema compiles
+bunx tsc --noEmit
+bun run lint
+```
+
+On VPS after deploy:
+```bash
+docker exec ledgerify-db psql -U ledgerify -d ledgerify -c \
+  "ALTER TABLE accounts ADD COLUMN IF NOT EXISTS current_balance numeric NOT NULL DEFAULT 0;"
+```
+
+**Step 4: Commit**
+
+```bash
+git checkout -b feat/cashew-visual-rework-v2
+git add src/lib/db/schema/accounts.ts drizzle/0001_accounts_current_balance.sql
+git commit -m "feat(schema): add currentBalance to accounts"
+```
+
+---
+
+### Task 2: Update transaction server actions to maintain `currentBalance`
+
+**Files:**
+- Modify: `src/app/actions/transactions.ts`
+- Modify: `src/lib/db/schema/accounts.ts` (already done — just importing it)
+
+**Context:** `createTransaction`, `updateTransaction`, `deleteTransaction` must update `accounts.currentBalance` after each write. Income adds, expense subtracts, transfer moves between accounts.
+
+**Step 1: Add accounts import to transactions action**
+
+In `src/app/actions/transactions.ts` add `accounts` to the schema import:
+
+```ts
+import { transactions, transactionTags, users, accounts } from "@/lib/db/schema";
+import { sql } from "drizzle-orm";
+```
+
+**Step 2: Add helper `adjustBalance` inside the file (after imports, before `normalizeOptionalTransactionFields`)**
+
+```ts
+async function adjustBalance(accountId: string, type: string, amount: number, sign: 1 | -1) {
+  const delta = type === 'income' ? amount * sign : type === 'expense' ? -amount * sign : 0
+  if (delta === 0) return
+  await db.update(accounts)
+    .set({ currentBalance: sql`current_balance + ${String(delta)}` })
+    .where(eq(accounts.id, accountId))
+}
+```
+
+**Step 3: Call `adjustBalance` in `createTransaction` after the insert**
+
+After `const [tx] = await db.insert(transactions)...returning()`, add:
+
+```ts
+await adjustBalance(data.accountId, data.type, data.amount, 1)
+if (data.type === 'transfer' && data.transferToId) {
+  await adjustBalance(data.transferToId, 'income', data.amount, 1)
+}
+```
+
+**Step 4: Call `adjustBalance` in `deleteTransaction` — reverse the effect**
+
+Before the soft-delete update, fetch the transaction first, then reverse:
+
+```ts
+const [existing] = await db.select().from(transactions)
+  .where(and(eq(transactions.id, id), eq(transactions.userId, session.user.id!)))
+if (existing) {
+  await adjustBalance(existing.accountId, existing.type, Number(existing.amount), -1)
+  if (existing.type === 'transfer' && existing.transferToId) {
+    await adjustBalance(existing.transferToId, 'income', Number(existing.amount), -1)
+  }
+}
+```
+
+**Step 5: Call `adjustBalance` in `updateTransaction` — reverse old, apply new**
+
+Before the update, fetch old transaction. After update, adjust both old and new balances.
+
+**Step 6: Verify**
+
+```bash
+bunx tsc --noEmit
+bun run lint
+```
+
+**Step 7: Commit**
+
+```bash
+git add src/app/actions/transactions.ts
+git commit -m "feat(actions): maintain account currentBalance on transaction write"
+```
+
+---
+
+### Task 3: Simplify `computeNetworth` to use `currentBalance`
+
+**Files:**
+- Modify: `src/lib/utils/networth.ts`
+
+**Step 1: Replace the per-account transaction sum loop**
+
+Current code loops over accounts and runs a SQL aggregate per account. Replace with:
+
+```ts
+// 3. Account cash balances — use maintained currentBalance field
+const accountRows = await db.select().from(accounts)
+  .where(and(eq(accounts.userId, userId), isNull(accounts.deletedAt)))
+
+let totalCash = 0
+for (const account of accountRows) {
+  const rate = await getRate(account.currency, baseCurrency)
+  totalCash += Number(account.currentBalance) * rate
+}
+```
+
+Remove the `sql` import if no longer needed.
+
+**Step 2: Verify**
+
+```bash
+bunx tsc --noEmit
+bun run lint
+bun run build
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/utils/networth.ts
+git commit -m "perf(networth): use account.currentBalance instead of transaction sum"
+```
+
+---
+
+## Segment 3: Transactions
+
+### Task 9: Add summary strip + segmented control to TransactionList
+
+**Files:**
+- Modify: `src/components/transactions/TransactionList.tsx`
+
+**Step 1: Add a `TransactionSummaryStrip` block at the top of the rendered list**
+
+Inside `TransactionList` (client component), compute from the currently filtered `filtered` array and render three `AmountBox`-style tiles above the list. Add these derivations right before the return:
+
+```tsx
+const summaryIncome  = filtered.filter(t => t.type === 'income' ).reduce((s,t) => s + Number(t.convertedAmount ?? t.amount), 0)
+const summaryExpense = filtered.filter(t => t.type === 'expense').reduce((s,t) => s + Number(t.convertedAmount ?? t.amount), 0)
+const summaryNet     = summaryIncome - summaryExpense
+```
+
+Render a strip above the date-grouped list:
+
+```tsx
+<div className="grid grid-cols-3 gap-3">
+  <AmountBox label="Income"   amount={summaryIncome}  currency={baseCurrency} icon={ArrowUpRight}  tone="positive" count="" />
+  <AmountBox label="Expenses" amount={summaryExpense} currency={baseCurrency} icon={ArrowDownLeft} tone="negative" count="" />
+  <AmountBox label="Net"      amount={summaryNet}     currency={baseCurrency} icon={ArrowLeftRight} tone={summaryNet >= 0 ? 'positive' : 'negative'} sign="always" count="" />
+</div>
+```
+
+Import `AmountBox` from `@/components/shared/quiet-ledger` and the three icons from `lucide-react`.
+
+**Step 2: Replace type filter chips with a segmented control**
+
+Find the existing filter chip row (renders `All`, `Income`, `Expenses`, `Transfers` chips). Replace it with a single segmented control div:
+
+```tsx
+<div className="flex rounded-2xl border bg-muted/50 p-1 gap-1">
+  {(['all','income','expense','transfer'] as const).map(t => (
+    <button
+      key={t}
+      type="button"
+      onClick={() => setTypeFilter(t)}
+      className={cn(
+        'flex-1 rounded-xl px-3 py-1.5 text-xs font-semibold capitalize transition',
+        typeFilter === t
+          ? 'bg-background shadow-sm text-foreground'
+          : 'text-muted-foreground hover:text-foreground'
+      )}
+    >
+      {t === 'all' ? 'All' : t.charAt(0).toUpperCase() + t.slice(1)}
+    </button>
+  ))}
+</div>
+```
+
+**Step 3: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/components/transactions/TransactionList.tsx
+git commit -m "feat(transactions): summary strip + segmented type control"
+```
+
+---
+
+### Task 10: Add category glyph + overflow delete to transaction rows
+
+**Files:**
+- Modify: `src/components/transactions/TransactionList.tsx`
+
+**Step 1: Add `CategoryGlyph` inline helper**
+
+At the top of the file, add a small helper component:
+
+```tsx
+function CategoryGlyph({ name, tone }: { name?: string; tone: 'positive' | 'negative' | 'info' }) {
+  const colors = {
+    positive: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300',
+    negative: 'bg-rose-100 text-rose-700 dark:bg-rose-950/50 dark:text-rose-300',
+    info:     'bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300',
+  }
+  const letter = name ? name[0].toUpperCase() : '?'
+  return (
+    <div className={cn('flex size-10 shrink-0 items-center justify-center rounded-2xl text-sm font-bold', colors[tone])}>
+      {letter}
+    </div>
+  )
+}
+```
+
+**Step 2: Update each transaction row to use `CategoryGlyph`**
+
+In the row render, replace the current `IconBadge` with:
+
+```tsx
+<CategoryGlyph
+  name={categoryMap[transaction.categoryId ?? ''] ?? transaction.type}
+  tone={transaction.type === 'income' ? 'positive' : transaction.type === 'expense' ? 'negative' : 'info'}
+/>
+```
+
+Where `categoryMap` is a `Record<string,string>` built from the `categories` prop passed to `TransactionList`.
+
+**Step 3: Move delete into an overflow menu**
+
+Replace the visible delete button on each row with a `DropdownMenu`:
+
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <button className="shrink-0 rounded-xl p-1.5 text-muted-foreground hover:bg-muted">
+      <MoreHorizontal className="size-4" />
+    </button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuItem className="text-destructive" onClick={() => handleDelete(transaction.id)}>
+      Delete
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+Import `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuTrigger` from `@/components/ui/dropdown-menu` and `MoreHorizontal` from `lucide-react`.
+
+**Step 4: Update row secondary line**
+
+Change the secondary text line below the note to show category and account:
+
+```tsx
+<p className="mt-0.5 text-xs text-muted-foreground truncate">
+  {categoryMap[transaction.categoryId ?? ''] ?? '—'} · {accountMap[transaction.accountId] ?? '—'} · {transaction.date}
+</p>
+```
+
+**Step 5: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint && bun run build
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/components/transactions/TransactionList.tsx
+git commit -m "feat(transactions): category glyph, overflow delete, richer row metadata"
+```
+
+---
+
+## Segment 4: Budgets & Goals
+
+### Task 11: Rework `BudgetCard` to progress-first surface
+
+**Files:**
+- Modify: `src/components/budgets/BudgetCard.tsx`
+
+**Step 1: Rewrite card body**
+
+Replace the current card with a layout that leads with spent/limit fraction and a colored progress bar. Key elements:
+
+- Budget name + period badge (Monthly / Weekly)
+- Category name if present
+- Large fraction: `₹spent / ₹limit`
+- Colored `ProgressMeter`: emerald < 70%, amber 70–99%, rose ≥ 100%
+- Status badge: `Safe` / `Watch` / `Over`
+- Days remaining line
+
+```tsx
+const pct     = limit > 0 ? Math.min((spent / limit) * 100, 100) : 0
+const barTone = pct >= 100 ? 'negative' : pct >= 70 ? 'warning' : 'positive'
+const status  = pct >= 100 ? 'Over'     : pct >= 70 ? 'Watch'    : 'Safe'
+const statusTone = pct >= 100 ? 'negative' : pct >= 70 ? 'warning' : 'positive'
+```
+
+Use `TonalWidget tone="budget"` as the card wrapper. Use `ProgressMeter`, `StatusPill`, `FinancialAmount` from `quiet-ledger`.
+
+**Step 2: Add health summary strip to budgets page**
+
+In `src/app/(app)/budgets/page.tsx`, above the budget card grid, add:
+
+```tsx
+<div className="flex flex-wrap gap-3">
+  <AmountBox label="Total budgeted" amount={totalBudgetLimit} currency={baseCurrency} icon={Wallet} tone="budget" count={`${budgetList.length} budget${budgetList.length !== 1 ? 's' : ''}`} />
+  <AmountBox label="Total spent"    amount={totalBudgetSpent} currency={baseCurrency} icon={TrendingDown} tone={overCount > 0 ? 'negative' : 'positive'} count={`${safeCount} safe · ${watchCount} watch · ${overCount} over`} />
+</div>
+```
+
+Compute `totalBudgetLimit`, `totalBudgetSpent`, `overCount`, `watchCount`, `safeCount` from `budgetProgress` array already computed in the page.
+
+**Step 3: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/components/budgets/BudgetCard.tsx src/app/(app)/budgets/page.tsx
+git commit -m "feat(budgets): progress-first BudgetCard + health summary strip"
+```
+
+---
+
+### Task 12: Rework `GoalCard` to motivating progress surface
+
+**Files:**
+- Modify: `src/components/budgets/GoalCard.tsx`
+
+**Step 1: Rewrite card body**
+
+Lead with goal name + deadline pressure, then current/target fraction, then teal progress bar, then contribute button.
+
+```tsx
+const pct       = target > 0 ? Math.min((current / target) * 100, 100) : 0
+const achieved  = current >= target
+const daysLeft  = deadline ? differenceInDays(new Date(deadline), new Date()) : null
+const pressure  = achieved ? 'Achieved!' : daysLeft === null ? null : daysLeft <= 0 ? 'Past deadline' : `${daysLeft} days left`
+const pressureTone = achieved ? 'positive' : daysLeft !== null && daysLeft <= 7 ? 'negative' : daysLeft !== null && daysLeft <= 30 ? 'warning' : 'neutral'
+```
+
+Use `TonalWidget tone="goal"` wrapper, `ProgressMeter tone="goal"`, `StatusPill` for pressure, `FinancialAmount` for amounts.
+
+**Step 2: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint && bun run build
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/components/budgets/GoalCard.tsx
+git commit -m "feat(goals): motivating GoalCard with deadline pressure + teal progress"
+```
+
+---
+
+## Segment 5: Wealth & Obligations
+
+### Task 13: Add `PortfolioSummaryWidget` to investments page
+
+**Files:**
+- Modify: `src/app/(app)/investments/page.tsx`
+
+**Step 1: Add a portfolio summary widget above the asset grid**
+
+The page already computes `totalInvested`, `totalCurrent`, `totalPnL`, `totalPnLPct`. Wrap them in a `TonalWidget tone="investment"` with `WidgetHeading` and three `AmountBox` tiles:
+
+```tsx
+<TonalWidget tone="investment" className="space-y-4">
+  <WidgetHeading icon={TrendingUp} tone="investment" eyebrow="Portfolio" title="Overview" />
+  <div className="grid gap-3 sm:grid-cols-3">
+    <AmountBox label="Current value" amount={totalCurrent}  currency={baseCurrency} icon={TrendingUp} tone="investment" count="At current prices" />
+    <AmountBox label="Cost basis"    amount={totalInvested} currency={baseCurrency} icon={WalletCards} tone="neutral"    count="Total invested" />
+    <AmountBox label="Unrealised P&L" amount={totalPnL}    currency={baseCurrency} icon={totalPnL >= 0 ? ArrowUpRight : ArrowDownLeft} tone={totalPnL >= 0 ? 'positive' : 'negative'} sign="always" count={`${totalPnLPct >= 0 ? '+' : ''}${totalPnLPct.toFixed(1)}% return`} />
+  </div>
+</TonalWidget>
+```
+
+Import `AmountBox`, `TonalWidget`, `WidgetHeading` from `@/components/shared/quiet-ledger` and needed icons.
+
+**Step 2: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/app/(app)/investments/page.tsx
+git commit -m "feat(investments): PortfolioSummaryWidget with P&L"
+```
+
+---
+
+### Task 14: Add `DebtSummaryWidget` to loans page + payoff progress on `LoanCard`
+
+**Files:**
+- Modify: `src/app/(app)/loans/page.tsx`
+- Modify: `src/components/loans/LoanCard.tsx`
+
+**Step 1: Add debt summary widget to loans page**
+
+The page already has `totalOutstanding` and `totalEmi`. Wrap them:
+
+```tsx
+<TonalWidget tone="loan" className="space-y-4">
+  <WidgetHeading icon={Landmark} tone="loan" eyebrow="Obligations" title="Debt overview" />
+  <div className="grid gap-3 sm:grid-cols-3">
+    <AmountBox label="Outstanding" amount={totalOutstanding} currency={summaryCurrency} icon={Landmark}   tone="loan"    count={`${loanList.length} active loan${loanList.length !== 1 ? 's' : ''}`} />
+    <AmountBox label="Monthly EMI" amount={totalEmi}         currency={summaryCurrency} icon={CreditCard} tone="warning" count="Total EMI this month" />
+    <AmountBox label="Avg interest" amount={avgInterest}    currency=""                icon={TrendingDown} tone="neutral" count="Weighted avg rate %" />
+  </div>
+</TonalWidget>
+```
+
+Compute `avgInterest` as `loanList.reduce((s,l) => s + Number(l.interestRate), 0) / Math.max(loanList.length, 1)`.
+
+**Step 2: Add payoff progress bar to `LoanCard`**
+
+In `src/components/loans/LoanCard.tsx`, compute payoff progress:
+
+```tsx
+const principal    = Number(loan.principal)
+const outstanding  = Number(loan.outstandingBalance ?? principal)
+const paidPct      = principal > 0 ? Math.min(((principal - outstanding) / principal) * 100, 100) : 0
+const monthsLeft   = loan.emiAmount && Number(loan.emiAmount) > 0
+  ? Math.ceil(outstanding / Number(loan.emiAmount))
+  : null
+```
+
+Render a `ProgressMeter tone="positive"` and a `{monthsLeft} months remaining` label at the bottom of the card.
+
+**Step 3: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/(app)/loans/page.tsx src/components/loans/LoanCard.tsx
+git commit -m "feat(loans): DebtSummaryWidget + payoff progress on LoanCard"
+```
+
+---
+
+### Task 15: Add `CoverageSummaryWidget` to insurance page + renewal urgency on `PolicyCard`
+
+**Files:**
+- Modify: `src/app/(app)/insurance/page.tsx`
+- Modify: `src/components/insurance/PolicyCard.tsx`
+
+**Step 1: Add coverage summary widget**
+
+The page already computes `totalAnnualPremium` and `expiringCount`. Add `totalCoverage`:
+
+```tsx
+const totalCoverage = policies.reduce((s, p) => s + Number(p.coverageAmount ?? 0), 0)
+```
+
+Render:
+
+```tsx
+<TonalWidget tone="insurance" className="space-y-4">
+  <WidgetHeading icon={ShieldCheck} tone="insurance" eyebrow="Protection" title="Coverage overview" />
+  <div className="grid gap-3 sm:grid-cols-3">
+    <AmountBox label="Total coverage"    amount={totalCoverage}      currency={summaryCurrency} icon={ShieldCheck}  tone="insurance" count={`${policies.length} active polic${policies.length !== 1 ? 'ies' : 'y'}`} />
+    <AmountBox label="Annual premium"    amount={totalAnnualPremium} currency={summaryCurrency} icon={CreditCard}   tone="neutral"   count="Total yearly cost" />
+    <AmountBox label="Renewing soon"     amount={expiringCount}      currency=""                icon={CalendarClock} tone={expiringCount > 0 ? 'warning' : 'positive'} count="Policies due in 30 days" />
+  </div>
+</TonalWidget>
+```
+
+**Step 2: Add renewal urgency state to `PolicyCard`**
+
+In `src/components/insurance/PolicyCard.tsx`, compute days until renewal and use `StatusPill` with the urgency tone (≤7 negative, ≤30 warning, else info).
+
+**Step 3: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint && bun run build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/(app)/insurance/page.tsx src/components/insurance/PolicyCard.tsx
+git commit -m "feat(insurance): CoverageSummaryWidget + renewal urgency on PolicyCard"
+```
+
+---
+
+## Segment 6: Reports & Import
+
+### Task 16: Standardise chart containers + add insight copy to each report page
+
+**Files:**
+- Modify: `src/app/(app)/reports/cash-flow/page.tsx`
+- Modify: `src/app/(app)/reports/category-breakdown/page.tsx`
+- Modify: `src/app/(app)/reports/investment-returns/page.tsx`
+- Modify: `src/app/(app)/reports/debt-payoff/page.tsx`
+- Modify: `src/app/(app)/reports/budget-vs-actual/page.tsx`
+
+**Step 1: Add a `ReportSummaryStrip` above each chart**
+
+For each report page, add 2–3 `AmountBox` tiles (or metric chips) derived from the already-loaded data. Examples:
+
+- **Cash flow**: avg monthly income, avg monthly expenses, net trend direction
+- **Category breakdown**: top category name + amount, total categories with spend
+- **Investment returns**: total P&L, best performer name
+- **Debt payoff**: total outstanding, projected months to clear
+- **Budget vs actual**: total over-budget count, total under-budget savings
+
+Render the strip as:
+
+```tsx
+<div className="grid gap-3 sm:grid-cols-3">
+  <AmountBox ... />
+  <AmountBox ... />
+  <AmountBox ... />
+</div>
+```
+
+**Step 2: Add one plain-language insight sentence per report**
+
+Derive from the data, render as a `TonalWidget tone="info"` banner just below the summary strip:
+
+```tsx
+<div className="rounded-2xl border bg-sky-50/80 px-4 py-3 text-sm text-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
+  {insightText}
+</div>
+```
+
+Example for cash flow: `"Expenses have exceeded income in 2 of the last 6 months."`
+
+**Step 3: Standardise Recharts chart containers**
+
+In all chart components (`CashFlowChart`, `CategoryPieChart`, `BudgetActualChart`):
+- Add `className="rounded-3xl border bg-card/80 p-4"` wrapper div
+- Set `CartesianGrid strokeDasharray="3 3" stroke="currentColor" className="opacity-10"`
+- Set `radius={[4,4,0,0]}` on `Bar` elements
+- Set chart container height: `height={300}` on mobile, `height={380}` on `sm:` via a responsive wrapper
+
+**Step 4: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/(app)/reports src/components/reports
+git commit -m "feat(reports): summary strips, insight copy, standardised chart containers"
+```
+
+---
+
+### Task 17: Rework import page to guided 3-step flow
+
+**Files:**
+- Modify: `src/app/(app)/import/page.tsx`
+
+**Step 1: Add a step indicator at the top**
+
+Replace the current two-card side-by-side layout with a linear 3-step flow. Add a step state:
+
+```tsx
+const [step, setStep] = useState<1 | 2 | 3>(1)
+```
+
+Render a simple step pill row:
+
+```tsx
+<div className="flex gap-2">
+  {[1,2,3].map(s => (
+    <div key={s} className={cn(
+      'flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold',
+      step >= s ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+    )}>{s}</div>
+  ))}
+</div>
+```
+
+**Step 2: Step 1 — Choose file**
+
+Show a drag-drop zone (`TonalWidget tone="info"`) with the file input and a template download link. On file selected, move to step 2.
+
+**Step 3: Step 2 — Review required columns**
+
+Parse the first line of the CSV client-side to extract detected column headers. Show a checklist of required columns (`date`, `amount`, `type`, `accountId`) with a check or cross per column. Provide a "Back" button and a "Looks good, import" button that triggers the upload and moves to step 3.
+
+**Step 4: Step 3 — Result**
+
+Show the existing result panel (imported count, errors). Add a "Import another file" button that resets to step 1.
+
+**Step 5: Verify**
+
+```bash
+bunx tsc --noEmit && bun run lint && bun run build
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/app/(app)/import/page.tsx
+git commit -m "feat(import): guided 3-step flow with column review"
+```
+
+---
+
+## Segment 7: Final Verification + PR
+
+### Task 18: Full build + VPS migration verify
+
+**Step 1: Run full validation**
+
+```bash
+bunx tsc --noEmit
+bun run lint
+bun run build
+```
+
+Expected: zero errors, zero lint warnings, successful build output.
+
+**Step 2: Push branch + open PR**
+
+```bash
+git push -u origin feat/cashew-visual-rework-v2
+gh pr create \
+  --title "feat: Cashew Visual Rework v2" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `accounts.currentBalance` schema column — maintained by transaction actions, eliminates per-account SQL aggregation in networth
+- Dashboard: BalanceSnapshotWidget, DailyMoneyWidget, QuickAddStrip, PlanningWidgets (budget health + goal progress tiles)
+- Transactions: summary strip, segmented control, category glyphs, overflow delete, richer row metadata
+- Budgets: progress-first BudgetCard + health summary strip
+- Goals: motivating GoalCard with deadline pressure + teal progress bar
+- Investments: PortfolioSummaryWidget with P&L
+- Loans: DebtSummaryWidget + payoff progress on LoanCard
+- Insurance: CoverageSummaryWidget + renewal urgency on PolicyCard
+- Reports: summary strips, insight copy, standardised chart containers
+- Import: guided 3-step flow with column review
+
+## Schema change
+
+One migration: `ALTER TABLE accounts ADD COLUMN current_balance NUMERIC NOT NULL DEFAULT 0`
+
+Apply on VPS after deploy:
+\`\`\`bash
+docker exec ledgerify-db psql -U ledgerify -d ledgerify -c \
+  "ALTER TABLE accounts ADD COLUMN IF NOT EXISTS current_balance numeric NOT NULL DEFAULT 0;"
+\`\`\`
+
+## No backend/domain logic changes
+
+All changes are UI-only except the schema column and its maintenance in transaction actions.
+EOF
+)"
+```
+
+**Step 3: Apply migration on VPS after merge**
+
+After CI passes and PR is merged:
+
+```bash
+ssh deploy@192.3.228.223 \
+  "docker exec ledgerify-db psql -U ledgerify -d ledgerify -c \
+   'ALTER TABLE accounts ADD COLUMN IF NOT EXISTS current_balance numeric NOT NULL DEFAULT 0;'"
+```
+
+---
+
+## Quick reference — key file paths
+
+| Area | File |
+|---|---|
+| Schema | `src/lib/db/schema/accounts.ts` |
+| Migration | `drizzle/0001_accounts_current_balance.sql` |
+| Transaction actions | `src/app/actions/transactions.ts` |
+| Networth util | `src/lib/utils/networth.ts` |
+| Design primitives | `src/components/shared/quiet-ledger.tsx` |
+| Dashboard page | `src/app/(app)/dashboard/page.tsx` |
+| DashboardSections | `src/components/dashboard/DashboardSections.tsx` |
+| NetworthCard | `src/components/dashboard/NetworthCard.tsx` |
+| CashFlowSummary | `src/components/dashboard/CashFlowSummary.tsx` |
+| QuickAddStrip | `src/components/dashboard/QuickAddStrip.tsx` (new) |
+| PlanningWidgets | `src/components/dashboard/PlanningWidgets.tsx` (new) |
+| TransactionList | `src/components/transactions/TransactionList.tsx` |
+| BudgetCard | `src/components/budgets/BudgetCard.tsx` |
+| GoalCard | `src/components/budgets/GoalCard.tsx` |
+| Investments page | `src/app/(app)/investments/page.tsx` |
+| LoanCard | `src/components/loans/LoanCard.tsx` |
+| Loans page | `src/app/(app)/loans/page.tsx` |
+| PolicyCard | `src/components/insurance/PolicyCard.tsx` |
+| Insurance page | `src/app/(app)/insurance/page.tsx` |
+| Report pages | `src/app/(app)/reports/*/page.tsx` |
+| Chart components | `src/components/reports/*.tsx` |
+| Import page | `src/app/(app)/import/page.tsx` |
+

--- a/docs/plans/2026-05-03-issue-7-remaining-fixes.md
+++ b/docs/plans/2026-05-03-issue-7-remaining-fixes.md
@@ -1,0 +1,725 @@
+# Issue #7 Remaining Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix all remaining correctness, security, and UX gaps identified in issue #7 that were not addressed by PR #8, making the app production-usable.
+
+**Architecture:** Server-action and API-route hardening (ownership guards, validation, revalidation), auth page redirect, `contributeToGoal` guard, networth `userId` filter, and `updateInvestmentPrice` server-side guard. No schema migrations required.
+
+**Tech Stack:** Next.js 16 App Router, Drizzle ORM, Zod v4, Auth.js v5 (`auth()`), TypeScript. No test framework exists — manual verification via `pnpm build` (type-check) after each task.
+
+---
+
+## Task 1: Redirect authenticated users away from auth pages
+
+**Problem:** Signed-in users can manually visit `/auth/login` and `/auth/register`.
+
+**Files:**
+- Modify: `src/app/auth/layout.tsx`
+
+**Step 1: Add redirect to auth layout**
+
+Replace the layout with a server component that calls `auth()` and redirects if a session exists.
+
+```tsx
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth/config'
+
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth()
+  if (session?.user?.id) redirect('/dashboard')
+
+  return (
+    <div className="min-h-screen bg-background px-4 py-8 sm:px-6">
+      <div className="mx-auto flex min-h-[calc(100vh-4rem)] w-full max-w-5xl items-center justify-center">
+        <div className="grid w-full gap-8 lg:grid-cols-[minmax(0,1fr)_24rem] lg:items-center">
+          <div className="hidden space-y-5 lg:block">
+            <div className="inline-flex rounded-full border bg-card/70 px-3 py-1 text-xs font-medium text-primary">
+              Quiet Ledger
+            </div>
+            <div className="space-y-3">
+              <h1
+                data-display-text
+                className="max-w-xl text-4xl font-bold tracking-tight text-foreground"
+              >
+                Your private money home for everyday clarity.
+              </h1>
+              <p className="max-w-lg text-base leading-7 text-muted-foreground">
+                Track cash flow, accounts, budgets, goals, wealth, and obligations in
+                a calm space built for personal and family use.
+              </p>
+            </div>
+            <div className="grid max-w-lg gap-3 text-sm text-muted-foreground">
+              <div className="rounded-3xl border bg-card/70 p-4">
+                Daily transactions stay quick to capture.
+              </div>
+              <div className="rounded-3xl border bg-card/70 p-4">
+                Planning, protection, and wealth views stay easy to scan.
+              </div>
+            </div>
+          </div>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+**Step 2: Remove `'use client'` directive** — the layout is now a server component (no directive needed).
+
+**Step 3: Verify**
+
+```bash
+pnpm build
+```
+
+Expected: no type errors. Visiting `/auth/login` while signed in now redirects to `/dashboard`.
+
+**Step 4: Commit**
+
+```bash
+git add src/app/auth/layout.tsx
+git commit -m "fix: redirect authenticated users away from auth pages"
+```
+
+---
+
+## Task 2: Normalize email in registration and login
+
+**Problem:** `registerUser` stores email as-is; `user@example.com` and `User@Example.com` can create duplicate accounts depending on DB collation.
+
+**Files:**
+- Modify: `src/app/actions/auth.ts`
+- Modify: `src/lib/auth/config.ts`
+
+**Step 1: Read `src/app/actions/auth.ts` to find the exact lines**
+
+Look for the block that checks for an existing user and inserts. Replace `parsed.data.email` with a normalized form:
+
+```ts
+const email = parsed.data.email.toLowerCase().trim()
+
+const existing = await db.select().from(users).where(eq(users.email, email)).limit(1)
+if (existing.length) return { error: 'Email already registered' }
+
+const hash = await bcrypt.hash(parsed.data.password, 12)
+await db.insert(users).values({
+  name: parsed.data.name,
+  email,
+  passwordHash: hash,
+})
+```
+
+**Step 2: Normalize email in `src/lib/auth/config.ts` authorize callback**
+
+Find the `authorize` function. Before querying the DB for the user, normalize:
+
+```ts
+const email = (credentials.email as string).toLowerCase().trim()
+// use `email` in eq(users.email, email) instead of credentials.email
+```
+
+**Step 3: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/actions/auth.ts src/lib/auth/config.ts
+git commit -m "fix: normalize email to lowercase on register and login"
+```
+
+---
+
+## Task 3: Guard `contributeToGoal` against negative/NaN amounts and already-achieved goals
+
+**Problem:** `contributeToGoal` in `src/app/actions/budgets.ts:90` accepts any `amount: number` — negative or NaN values can corrupt `currentAmount`. It also allows contributions to already-achieved goals.
+
+**Files:**
+- Modify: `src/app/actions/budgets.ts`
+
+**Step 1: Add validation at the top of `contributeToGoal`**
+
+After the `session` check (line 92), add:
+
+```ts
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return { error: 'Amount must be a positive number' }
+  }
+```
+
+**Step 2: Reject contributions to achieved goals**
+
+After the `rows.length` check (line 97), add:
+
+```ts
+  if (goal.status === 'achieved') {
+    return { error: 'This goal has already been achieved' }
+  }
+```
+
+**Step 3: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/actions/budgets.ts
+git commit -m "fix: guard contributeToGoal against invalid amounts and achieved goals"
+```
+
+---
+
+## Task 4: Validate `linkedAccountId` ownership in `createSavingsGoal`
+
+**Problem:** `createSavingsGoal` accepts `linkedAccountId` without checking it belongs to the current user.
+
+**Files:**
+- Modify: `src/app/actions/budgets.ts`
+- Add import: `accounts` table, `isNull` from drizzle (already imported via `budgets.ts` — check first)
+
+**Step 1: Add accounts to imports if missing**
+
+At top of `src/app/actions/budgets.ts`, ensure `accounts` is imported from `@/lib/db/schema`.
+
+**Step 2: Add ownership check after schema parse in `createSavingsGoal`**
+
+After `if (!parsed.success)` check (line 73), before the `db.insert`, add:
+
+```ts
+  if (d.linkedAccountId) {
+    const acctCheck = await db.query.accounts.findFirst({
+      where: and(
+        eq(accounts.id, d.linkedAccountId),
+        eq(accounts.userId, session.user.id),
+        isNull(accounts.deletedAt),
+      ),
+    })
+    if (!acctCheck) return { error: 'Account not found or not yours' }
+  }
+```
+
+**Step 3: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/actions/budgets.ts
+git commit -m "fix: validate linkedAccountId ownership in createSavingsGoal"
+```
+
+---
+
+## Task 5: Add `userId` filter to networth transaction balance query
+
+**Problem:** `computeNetworth` in `src/lib/utils/networth.ts:54` queries transactions by `accountId` only, without `transactions.userId`. Practically safe since account IDs are UUIDs, but should be explicit.
+
+**Files:**
+- Modify: `src/lib/utils/networth.ts`
+
+**Step 1: Add `userId` to the transactions WHERE clause**
+
+Find the `.where(and(...))` block at line 54–57:
+
+```ts
+      .where(and(
+        eq(transactions.accountId, account.id),
+        isNull(transactions.deletedAt),
+      ))
+```
+
+Replace with:
+
+```ts
+      .where(and(
+        eq(transactions.accountId, account.id),
+        eq(transactions.userId, userId),
+        isNull(transactions.deletedAt),
+      ))
+```
+
+**Step 2: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/utils/networth.ts
+git commit -m "fix: add userId filter to networth transaction balance query"
+```
+
+---
+
+## Task 6: Guard `updateInvestmentPrice` against invalid values server-side
+
+**Problem:** `updateInvestmentPrice` in `src/app/actions/investments.ts:61` accepts any `currentPrice: number` — negative or NaN values can be stored.
+
+**Files:**
+- Modify: `src/app/actions/investments.ts`
+
+**Step 1: Add validation after the session check**
+
+After `if (!session?.user?.id)` (line 63), add:
+
+```ts
+  if (!Number.isFinite(currentPrice) || currentPrice < 0) {
+    return { error: 'Price must be a non-negative number' }
+  }
+```
+
+**Step 2: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/app/actions/investments.ts
+git commit -m "fix: validate currentPrice in updateInvestmentPrice server action"
+```
+
+---
+
+## Task 7: Uppercase currency in investments, loans, and insurance actions
+
+**Problem:** `createInvestment`, `createLoan`, and `createPolicy` do not uppercase the `currency` field, while all other actions do (transactions, accounts, budgets, profile).
+
+**Files:**
+- Modify: `src/app/actions/investments.ts`
+- Modify: `src/app/actions/loans.ts`
+- Modify: `src/app/actions/insurance.ts`
+
+**Step 1: investments.ts — uppercase currency before parsing**
+
+In `createInvestment`, the parse is:
+```ts
+  const parsed = investmentSchema.safeParse(Object.fromEntries(formData))
+```
+
+Replace with:
+```ts
+  const raw = Object.fromEntries(formData)
+  const parsed = investmentSchema.safeParse({
+    ...raw,
+    currency: String(raw.currency ?? '').toUpperCase(),
+  })
+```
+
+**Step 2: loans.ts — uppercase currency before parsing**
+
+In `createLoan`, replace:
+```ts
+  const parsed = loanSchema.safeParse(Object.fromEntries(formData))
+```
+With:
+```ts
+  const raw = Object.fromEntries(formData)
+  const parsed = loanSchema.safeParse({
+    ...raw,
+    currency: String(raw.currency ?? '').toUpperCase(),
+  })
+```
+
+**Step 3: insurance.ts — uppercase currency before parsing**
+
+In `createPolicy`, replace:
+```ts
+  const parsed = insuranceSchema.safeParse(Object.fromEntries(formData))
+```
+With:
+```ts
+  const raw = Object.fromEntries(formData)
+  const parsed = insuranceSchema.safeParse({
+    ...raw,
+    currency: String(raw.currency ?? '').toUpperCase(),
+  })
+```
+
+**Step 4: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/actions/investments.ts src/app/actions/loans.ts src/app/actions/insurance.ts
+git commit -m "fix: uppercase currency in investment, loan, and insurance actions"
+```
+
+---
+
+## Task 8: Fix optional numeric coercion (blank → null) in investment schema
+
+**Problem:** `investmentSchema` uses `z.coerce.number().optional()` for `quantity`, `buyPrice`, `currentPrice`, `interestRate`. Empty form strings coerce to `0` via Zod's coerce, not `undefined`/`null`, so blank optional fields are stored as `0`.
+
+**Files:**
+- Modify: `src/lib/validations/investment.ts`
+
+**Step 1: Replace coerce-optional fields with a nullable transform**
+
+Replace the four optional numeric fields with a pattern that treats empty string as `undefined`:
+
+```ts
+import { z } from 'zod'
+
+const optionalPositiveNumber = z.preprocess(
+  (v) => (v === '' || v == null ? undefined : v),
+  z.coerce.number().positive().optional(),
+)
+
+export const investmentSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  assetType: z.enum(['stock', 'mf', 'crypto', 'fd', 'ppf', 'nps', 'gold', 'silver', 'real_estate', 'savings', 'other']),
+  currency: z.string().length(3),
+  quantity: optionalPositiveNumber,
+  buyPrice: optionalPositiveNumber,
+  currentPrice: optionalPositiveNumber,
+  maturityDate: z.string().optional(),
+  interestRate: optionalPositiveNumber,
+})
+```
+
+Keep `investmentTxSchema` unchanged.
+
+**Step 2: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/validations/investment.ts
+git commit -m "fix: treat empty optional numeric fields as undefined in investmentSchema"
+```
+
+---
+
+## Task 9: Validate timezone in `updateProfile`
+
+**Problem:** `updateProfile` accepts any free-text string for `timezone` and stores it. Invalid values silently persist.
+
+**Files:**
+- Modify: `src/app/actions/settings.ts`
+
+**Step 1: Add timezone validation using `Intl.supportedValuesOf`**
+
+In the `updateProfile` schema definition (lines 13–17), add a `.refine` on the timezone field:
+
+```ts
+  const schema = z.object({
+    name: z.string().min(1),
+    defaultCurrency: z.string().length(3),
+    timezone: z.string().min(1).refine(
+      (tz) => {
+        try {
+          Intl.DateTimeFormat(undefined, { timeZone: tz })
+          return true
+        } catch {
+          return false
+        }
+      },
+      { message: 'Invalid timezone' },
+    ),
+  })
+```
+
+**Step 2: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/app/actions/settings.ts
+git commit -m "fix: validate timezone against Intl in updateProfile"
+```
+
+---
+
+## Task 10: Validate `endDate >= startDate` in budget and insurance schemas
+
+**Problem:** `budgetSchema` and `insuranceSchema` accept `endDate` before `startDate` without error.
+
+**Files:**
+- Modify: `src/lib/validations/budget.ts`
+- Modify: `src/lib/validations/insurance.ts`
+
+**Step 1: Add `.refine` to `budgetSchema`**
+
+After the existing fields, add a superRefine or wrap in `.refine`:
+
+```ts
+export const budgetSchema = z.object({
+  categoryId: z.string().uuid().optional(),
+  name: z.string().min(1, 'Name is required'),
+  amount: z.coerce.number().positive(),
+  currency: z.string().length(3),
+  periodType: z.enum(['monthly', 'weekly']),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+}).refine(
+  (d) => !d.endDate || d.endDate >= d.startDate,
+  { message: 'End date must be on or after start date', path: ['endDate'] },
+)
+```
+
+**Step 2: Add `.refine` to `insuranceSchema`**
+
+Read `src/lib/validations/insurance.ts` first to see the exact field names, then add:
+
+```ts
+}).refine(
+  (d) => !d.endDate || !d.startDate || d.endDate >= d.startDate,
+  { message: 'End date must be on or after start date', path: ['endDate'] },
+)
+```
+
+**Step 3: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/lib/validations/budget.ts src/lib/validations/insurance.ts
+git commit -m "fix: validate endDate >= startDate in budget and insurance schemas"
+```
+
+---
+
+## Task 11: Broaden revalidation after mutations
+
+**Problem:** Most actions only revalidate their own page. Other pages that display the same data (dashboard, reports, networth, budgets) stay stale until navigation.
+
+**Files:**
+- Modify: `src/app/actions/transactions.ts`
+- Modify: `src/app/actions/settings.ts`
+- Modify: `src/app/actions/budgets.ts`
+- Modify: `src/app/actions/investments.ts`
+- Modify: `src/app/actions/loans.ts`
+- Modify: `src/app/actions/insurance.ts`
+
+**Step 1: transactions.ts — add missing revalidations**
+
+`createTransaction`, `updateTransaction`, `deleteTransaction` currently revalidate `/transactions` and `/dashboard`. Add:
+
+```ts
+revalidatePath('/reports/cash-flow')
+revalidatePath('/reports/category-breakdown')
+revalidatePath('/reports/budget-vs-actual')
+revalidatePath('/networth')
+revalidatePath('/budgets')
+```
+
+**Step 2: settings.ts — broaden after account/category mutations**
+
+`deleteAccount` and `createAccount`: add `/dashboard`, `/transactions`, `/networth`, `/reports/cash-flow`.
+
+`deleteCategory` and `createCategory`: add `/dashboard`, `/transactions`, `/budgets`, `/reports/category-breakdown`.
+
+`updateProfile`: add `/dashboard`, `/networth` (default currency change affects conversions).
+
+**Step 3: budgets.ts — broaden budget revalidations**
+
+`createBudget` and `deleteBudget`: add `/dashboard`, `/reports/budget-vs-actual`.
+
+`createSavingsGoal` and `deleteSavingsGoal` and `contributeToGoal`: already revalidate `/budgets/goals` — also add `/dashboard`.
+
+**Step 4: investments.ts — broaden**
+
+`createInvestment`, `updateInvestmentPrice`, `deleteInvestment`: add `/dashboard`, `/networth`, `/reports/investment-returns`.
+
+**Step 5: loans.ts — broaden**
+
+`createLoan`, `recordLoanPayment`, `deleteLoan`: add `/dashboard`, `/networth`, `/reports/debt-payoff`.
+
+**Step 6: insurance.ts — broaden**
+
+`createPolicy`, `recordPremiumPayment`, `deletePolicy`: add `/dashboard`.
+
+**Step 7: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 8: Commit**
+
+```bash
+git add src/app/actions/transactions.ts src/app/actions/settings.ts src/app/actions/budgets.ts src/app/actions/investments.ts src/app/actions/loans.ts src/app/actions/insurance.ts
+git commit -m "fix: broaden revalidatePath calls after all mutations to keep dependent pages fresh"
+```
+
+---
+
+## Task 12: Expose `recordLoanPayment` and `recordPremiumPayment` via UI
+
+**Problem:** Both actions exist and work, but no UI calls them — users have no way to record loan payments or insurance premium payments.
+
+**Files:**
+- Modify: `src/components/loans/LoanCard.tsx`
+- Modify: `src/components/insurance/PolicyCard.tsx`
+- Read these files first to understand current structure before editing.
+
+**Step 1: Read the existing LoanCard and PolicyCard to understand their structure**
+
+```bash
+cat src/components/loans/LoanCard.tsx
+cat src/components/insurance/PolicyCard.tsx
+```
+
+**Step 2: Add a "Record payment" Dialog to LoanCard**
+
+Inside `LoanCard`, after the existing delete dialog, add a new Dialog that contains a small form:
+- Fields: `date` (date input, default today), `amount` (number input), `principalComponent` (number, optional), `interestComponent` (number, optional), `status` (select: paid|partial|missed, default paid)
+- On submit: call `recordLoanPayment` as a form action via `useActionState` or a `startTransition` handler
+- Show a toast on success/error using `sonner`
+
+Skeleton:
+
+```tsx
+import { recordLoanPayment } from '@/app/actions/loans'
+import { useState, useTransition } from 'react'
+import { toast } from 'sonner'
+
+// Inside component:
+const [payPending, startPayTransition] = useTransition()
+
+function handlePayment(e: React.FormEvent<HTMLFormElement>) {
+  e.preventDefault()
+  const fd = new FormData(e.currentTarget)
+  fd.set('loanId', loan.id)
+  startPayTransition(async () => {
+    const result = await recordLoanPayment(null, fd)
+    if (result?.error) toast.error(result.error)
+    else toast.success('Payment recorded')
+  })
+}
+```
+
+Add a "Record payment" button (secondary/outline style) next to the delete button, opening a Dialog with the form.
+
+**Step 3: Add a "Record payment" Dialog to PolicyCard**
+
+Same pattern using `recordPremiumPayment`:
+- Fields: `date` (date input, default today), `amount` (number), `status` (select: paid|due|missed, default paid)
+- `policyId` set as hidden/fd field
+
+**Step 4: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/components/loans/LoanCard.tsx src/components/insurance/PolicyCard.tsx
+git commit -m "feat: expose recordLoanPayment and recordPremiumPayment via card UI dialogs"
+```
+
+---
+
+## Task 13: Replace `"Saving..."` / `"Adding..."` / `"Deleting..."` with unicode ellipsis
+
+**Problem:** Issue #7 audit flagged that several buttons use ASCII `...` instead of the unicode ellipsis character `…` (`\u2026`). This is both a copy standard issue and a web guideline compliance issue.
+
+**Files:** Any component with a pending label using `"..."`.
+
+**Step 1: Search for ASCII ellipsis in pending labels**
+
+```bash
+grep -r '\.\.\.' src/components --include="*.tsx" -l
+```
+
+**Step 2: Replace all occurrences in those files**
+
+For each file found, replace patterns like:
+- `"Saving..."` → `"Saving…"`
+- `"Adding..."` → `"Adding…"`
+- `"Deleting..."` → `"Deleting…"` (already fixed in PR #8 for some; verify no others remain)
+- `"Signing in..."` → `"Signing in…"` (in `src/app/auth/login/page.tsx`)
+- `"Submitting..."` → `"Submitting…"` (if present)
+
+**Step 3: Verify**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "fix: use unicode ellipsis in all pending button labels"
+```
+
+---
+
+## Task 14: Final build verification and push
+
+**Step 1: Run full build**
+
+```bash
+pnpm build
+```
+
+Expected: zero TypeScript errors, zero build failures.
+
+**Step 2: If build passes, push to PR branch**
+
+```bash
+git push
+```
+
+**Step 3: Update PR description**
+
+Add a note to PR #8 that the review feedback has been addressed and these additional correctness fixes have been applied.
+
+```bash
+gh pr comment 8 --body "All code review fixes applied plus remaining issue #7 correctness gaps resolved (Tasks 1–13 of docs/plans/2026-05-03-issue-7-remaining-fixes.md)."
+```
+
+---
+
+## Summary of All Fixes
+
+| Task | Area | Type |
+|------|------|------|
+| 1 | Auth pages redirect when signed in | Security |
+| 2 | Email normalization on register/login | Correctness |
+| 3 | `contributeToGoal` guards (negative amount, achieved status) | Correctness |
+| 4 | `linkedAccountId` ownership in `createSavingsGoal` | Security |
+| 5 | `userId` filter in networth transaction query | Correctness |
+| 6 | `updateInvestmentPrice` validates price server-side | Correctness |
+| 7 | Currency uppercased in investment/loan/insurance | Consistency |
+| 8 | Optional numeric coercion (blank → null) in investmentSchema | Correctness |
+| 9 | Timezone validated via `Intl` in `updateProfile` | Correctness |
+| 10 | `endDate >= startDate` in budget and insurance schemas | Validation |
+| 11 | Broad `revalidatePath` after all mutations | UX/Staleness |
+| 12 | Loan payment and premium payment UI | Feature/UX |
+| 13 | Unicode ellipsis in pending labels | Polish |

--- a/docs/plans/2026-05-03-rest-api-v1.md
+++ b/docs/plans/2026-05-03-rest-api-v1.md
@@ -1,0 +1,1277 @@
+# REST API v1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `/api/v1/` REST layer so an AI agent can authenticate with email+password and perform full CRUD on all entities (accounts, categories, transactions, budgets, goals, investments, loans, insurance).
+
+**Architecture:** Session-cookie auth via the existing NextAuth `/api/auth/csrf` + `/api/auth/callback/credentials` flow. A shared `resolveSession(req)` helper validates the session cookie on every `/api/v1/` route. All routes accept/return JSON and reuse the existing Drizzle schema and validation logic — no new DB tables or migrations needed.
+
+**Tech Stack:** Next.js 16 App Router API routes, Drizzle ORM, Zod v4, Auth.js v5 (`auth()`), TypeScript.
+
+---
+
+## Auth Flow (for agent reference)
+
+```
+# Step 1 — get CSRF token
+GET /api/auth/csrf
+→ { csrfToken: "..." }   + Set-Cookie: authjs.csrf-token=...
+
+# Step 2 — sign in
+POST /api/auth/callback/credentials
+Content-Type: application/x-www-form-urlencoded
+Cookie: <csrf cookie from step 1>
+
+email=user@example.com&password=secret&csrfToken=<token>&callbackUrl=https://money.shenthar.me/dashboard&redirect=false&json=true
+→ Set-Cookie: authjs.session-token=...
+
+# Step 3 — use session on all /api/v1/* requests
+GET /api/v1/accounts
+Authorization: (not needed — use Cookie header)
+Cookie: authjs.session-token=<token>
+```
+
+---
+
+## Task 1: Shared auth helper
+
+**Files:**
+- Create: `src/lib/api/auth.ts`
+
+**Step 1: Create the helper**
+
+```ts
+// src/lib/api/auth.ts
+import { auth } from '@/lib/auth/config'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function resolveSession(
+  req: NextRequest,
+): Promise<{ userId: string } | NextResponse> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return { userId: session.user.id }
+}
+```
+
+**Step 2: Verify build**
+
+```bash
+pnpm build
+```
+
+Expected: zero errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/api/auth.ts
+git commit -m "feat(api): add shared session resolver for v1 routes"
+```
+
+---
+
+## Task 2: Accounts endpoints
+
+**Files:**
+- Create: `src/app/api/v1/accounts/route.ts`
+- Create: `src/app/api/v1/accounts/[id]/route.ts`
+
+**Step 1: Create `src/app/api/v1/accounts/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { accounts } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(['bank', 'wallet', 'cash', 'savings']),
+  currency: z.string().length(3),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(accounts)
+    .where(and(eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const [row] = await db.insert(accounts)
+    .values({ ...parsed.data, userId: auth.userId })
+    .returning()
+
+  revalidatePath('/settings/accounts')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/networth')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/accounts/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { accounts } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(accounts)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(accounts.id, id), eq(accounts.userId, auth.userId)))
+
+  revalidatePath('/settings/accounts')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/networth')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/api/v1/accounts/route.ts src/app/api/v1/accounts/[id]/route.ts
+git commit -m "feat(api): add /api/v1/accounts GET, POST, DELETE"
+```
+
+---
+
+## Task 3: Categories endpoints
+
+**Files:**
+- Create: `src/app/api/v1/categories/route.ts`
+- Create: `src/app/api/v1/categories/[id]/route.ts`
+
+**Step 1: Create `src/app/api/v1/categories/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { categories } from '@/lib/db/schema'
+import { eq, and, isNull, or } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(['income', 'expense']),
+  color: z.string().optional(),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(categories)
+    .where(and(
+      isNull(categories.deletedAt),
+      or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+    ))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const [row] = await db.insert(categories)
+    .values({ ...parsed.data, userId: auth.userId })
+    .returning()
+
+  revalidatePath('/settings/categories')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/budgets')
+  revalidatePath('/reports/category-breakdown')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/categories/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { categories } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(categories)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(categories.id, id), eq(categories.userId, auth.userId)))
+
+  revalidatePath('/settings/categories')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/budgets')
+  revalidatePath('/reports/category-breakdown')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/api/v1/categories/route.ts src/app/api/v1/categories/[id]/route.ts
+git commit -m "feat(api): add /api/v1/categories GET, POST, DELETE"
+```
+
+---
+
+## Task 4: Transactions endpoints
+
+**Files:**
+- Create: `src/app/api/v1/transactions/route.ts`
+- Create: `src/app/api/v1/transactions/[id]/route.ts`
+
+**Step 1: Create `src/app/api/v1/transactions/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { transactions, users, accounts, categories } from '@/lib/db/schema'
+import { eq, and, isNull, or, gte, lte } from 'drizzle-orm'
+import { z } from 'zod'
+import { getRate } from '@/lib/utils/currency'
+import { revalidatePath } from 'next/cache'
+
+const createSchema = z.object({
+  accountId: z.string().uuid(),
+  type: z.enum(['income', 'expense']),
+  amount: z.coerce.number().positive(),
+  currency: z.string().length(3),
+  categoryId: z.string().uuid().optional(),
+  note: z.string().max(500).optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  isRecurring: z.coerce.boolean().default(false),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { searchParams } = new URL(req.url)
+  const type = searchParams.get('type')
+  const accountId = searchParams.get('accountId')
+  const from = searchParams.get('from')
+  const to = searchParams.get('to')
+  const limit = Math.min(Number(searchParams.get('limit') ?? 100), 500)
+
+  const conditions = [
+    eq(transactions.userId, auth.userId),
+    isNull(transactions.deletedAt),
+  ] as ReturnType<typeof eq>[]
+  if (type) conditions.push(eq(transactions.type, type as 'income' | 'expense'))
+  if (accountId) conditions.push(eq(transactions.accountId, accountId))
+  if (from) conditions.push(gte(transactions.date, from))
+  if (to) conditions.push(lte(transactions.date, to))
+
+  const rows = await db.select().from(transactions)
+    .where(and(...conditions))
+    .limit(limit)
+    .orderBy(transactions.date)
+
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+
+  const accountCheck = await db.query.accounts.findFirst({
+    where: and(eq(accounts.id, d.accountId), eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)),
+  })
+  if (!accountCheck) return NextResponse.json({ error: 'Account not found or not yours' }, { status: 400 })
+
+  if (d.categoryId) {
+    const catCheck = await db.query.categories.findFirst({
+      where: and(
+        eq(categories.id, d.categoryId),
+        isNull(categories.deletedAt),
+        or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+      ),
+    })
+    if (!catCheck) return NextResponse.json({ error: 'Category not found or not yours' }, { status: 400 })
+  }
+
+  const user = await db.query.users.findFirst({ where: eq(users.id, auth.userId) })
+  const baseCurrency = user?.defaultCurrency ?? 'INR'
+  const rate = await getRate(d.currency, baseCurrency)
+
+  const [row] = await db.insert(transactions).values({
+    ...d,
+    userId: auth.userId,
+    amount: String(d.amount),
+    convertedAmount: String(d.amount * rate),
+    baseCurrency,
+  }).returning()
+
+  revalidatePath('/transactions')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/cash-flow')
+  revalidatePath('/reports/category-breakdown')
+  revalidatePath('/reports/budget-vs-actual')
+  revalidatePath('/networth')
+  revalidatePath('/budgets')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/transactions/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { transactions } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(transactions)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(transactions.id, id), eq(transactions.userId, auth.userId)))
+
+  revalidatePath('/transactions')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/cash-flow')
+  revalidatePath('/reports/category-breakdown')
+  revalidatePath('/reports/budget-vs-actual')
+  revalidatePath('/networth')
+  revalidatePath('/budgets')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/api/v1/transactions/route.ts src/app/api/v1/transactions/[id]/route.ts
+git commit -m "feat(api): add /api/v1/transactions GET, POST, DELETE"
+```
+
+---
+
+## Task 5: Budgets endpoints
+
+**Files:**
+- Create: `src/app/api/v1/budgets/route.ts`
+- Create: `src/app/api/v1/budgets/[id]/route.ts`
+
+**Step 1: Create `src/app/api/v1/budgets/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { budgets, categories } from '@/lib/db/schema'
+import { eq, and, isNull, or } from 'drizzle-orm'
+import { budgetSchema } from '@/lib/validations/budget'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(budgets)
+    .where(and(eq(budgets.userId, auth.userId), isNull(budgets.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = budgetSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+    categoryId: body.categoryId || undefined,
+    endDate: body.endDate || undefined,
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  if (d.categoryId) {
+    const catCheck = await db.query.categories.findFirst({
+      where: and(eq(categories.id, d.categoryId), isNull(categories.deletedAt), or(eq(categories.userId, auth.userId), isNull(categories.userId))),
+    })
+    if (!catCheck) return NextResponse.json({ error: 'Category not found or not yours' }, { status: 400 })
+  }
+
+  const [row] = await db.insert(budgets).values({
+    userId: auth.userId,
+    name: d.name,
+    categoryId: d.categoryId || null,
+    amount: String(d.amount),
+    currency: d.currency,
+    periodType: d.periodType,
+    startDate: d.startDate,
+    endDate: d.endDate || null,
+  }).returning()
+
+  revalidatePath('/budgets')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/budget-vs-actual')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/budgets/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { budgets } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(budgets)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(budgets.id, id), eq(budgets.userId, auth.userId)))
+
+  revalidatePath('/budgets')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/budget-vs-actual')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/api/v1/budgets/route.ts src/app/api/v1/budgets/[id]/route.ts
+git commit -m "feat(api): add /api/v1/budgets GET, POST, DELETE"
+```
+
+---
+
+## Task 6: Goals endpoints
+
+**Files:**
+- Create: `src/app/api/v1/goals/route.ts`
+- Create: `src/app/api/v1/goals/[id]/route.ts`
+- Create: `src/app/api/v1/goals/[id]/contribute/route.ts`
+
+**Step 1: Create `src/app/api/v1/goals/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { savingsGoals, accounts } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { savingsGoalSchema } from '@/lib/validations/budget'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(savingsGoals)
+    .where(and(eq(savingsGoals.userId, auth.userId), isNull(savingsGoals.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = savingsGoalSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+    description: body.description || undefined,
+    linkedAccountId: body.linkedAccountId || undefined,
+    deadline: body.deadline || undefined,
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  if (d.linkedAccountId) {
+    const acctCheck = await db.query.accounts.findFirst({
+      where: and(eq(accounts.id, d.linkedAccountId), eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)),
+    })
+    if (!acctCheck) return NextResponse.json({ error: 'Account not found or not yours' }, { status: 400 })
+  }
+
+  const [row] = await db.insert(savingsGoals).values({
+    userId: auth.userId,
+    name: d.name,
+    description: d.description || null,
+    targetAmount: String(d.targetAmount),
+    currency: d.currency,
+    linkedAccountId: d.linkedAccountId || null,
+    deadline: d.deadline || null,
+  }).returning()
+
+  revalidatePath('/budgets/goals')
+  revalidatePath('/dashboard')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/goals/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { savingsGoals } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(savingsGoals)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(savingsGoals.id, id), eq(savingsGoals.userId, auth.userId)))
+
+  revalidatePath('/budgets/goals')
+  revalidatePath('/dashboard')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Create `src/app/api/v1/goals/[id]/contribute/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { savingsGoals } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const schema = z.object({ amount: z.number().positive() })
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const { amount } = parsed.data
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return NextResponse.json({ error: 'Amount must be a positive number' }, { status: 400 })
+  }
+
+  const rows = await db.select().from(savingsGoals)
+    .where(and(eq(savingsGoals.id, id), eq(savingsGoals.userId, auth.userId), isNull(savingsGoals.deletedAt)))
+    .limit(1)
+  if (!rows.length) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const goal = rows[0]
+  if (goal.status === 'achieved') return NextResponse.json({ error: 'Goal already achieved' }, { status: 400 })
+
+  const newAmount = Number(goal.currentAmount) + amount
+  const isAchieved = newAmount >= Number(goal.targetAmount)
+
+  const [row] = await db.update(savingsGoals)
+    .set({ currentAmount: String(newAmount), status: isAchieved ? 'achieved' : 'active', updatedAt: new Date() })
+    .where(eq(savingsGoals.id, id))
+    .returning()
+
+  revalidatePath('/budgets/goals')
+  revalidatePath('/dashboard')
+  return NextResponse.json(row)
+}
+```
+
+**Step 4: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/v1/goals/route.ts src/app/api/v1/goals/[id]/route.ts src/app/api/v1/goals/[id]/contribute/route.ts
+git commit -m "feat(api): add /api/v1/goals GET, POST, DELETE and contribute"
+```
+
+---
+
+## Task 7: Investments endpoints
+
+**Files:**
+- Create: `src/app/api/v1/investments/route.ts`
+- Create: `src/app/api/v1/investments/[id]/route.ts`
+- Create: `src/app/api/v1/investments/[id]/price/route.ts`
+
+**Step 1: Create `src/app/api/v1/investments/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { investments } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { investmentSchema } from '@/lib/validations/investment'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(investments)
+    .where(and(eq(investments.userId, auth.userId), isNull(investments.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = investmentSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const data = parsed.data
+  const [row] = await db.insert(investments).values({
+    userId: auth.userId,
+    name: data.name,
+    assetType: data.assetType,
+    currency: data.currency,
+    quantity: data.quantity != null ? String(data.quantity) : null,
+    buyPrice: data.buyPrice != null ? String(data.buyPrice) : null,
+    currentPrice: data.currentPrice != null ? String(data.currentPrice) : null,
+    maturityDate: data.maturityDate || null,
+    interestRate: data.interestRate != null ? String(data.interestRate) : null,
+  }).returning()
+
+  revalidatePath('/investments')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/investment-returns')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/investments/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { investments } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(investments)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(investments.id, id), eq(investments.userId, auth.userId)))
+
+  revalidatePath('/investments')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/investment-returns')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Create `src/app/api/v1/investments/[id]/price/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { investments } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const schema = z.object({ currentPrice: z.number().min(0) })
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const { currentPrice } = parsed.data
+  if (!Number.isFinite(currentPrice) || currentPrice < 0) {
+    return NextResponse.json({ error: 'Price must be a non-negative number' }, { status: 400 })
+  }
+
+  const [row] = await db.update(investments)
+    .set({ currentPrice: String(currentPrice), currentPriceUpdatedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(investments.id, id), eq(investments.userId, auth.userId)))
+    .returning()
+
+  revalidatePath('/investments')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/investment-returns')
+  return NextResponse.json(row)
+}
+```
+
+**Step 4: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/v1/investments/route.ts src/app/api/v1/investments/[id]/route.ts src/app/api/v1/investments/[id]/price/route.ts
+git commit -m "feat(api): add /api/v1/investments GET, POST, DELETE, PATCH price"
+```
+
+---
+
+## Task 8: Loans endpoints
+
+**Files:**
+- Create: `src/app/api/v1/loans/route.ts`
+- Create: `src/app/api/v1/loans/[id]/route.ts`
+- Create: `src/app/api/v1/loans/[id]/payment/route.ts`
+
+**Step 1: Create `src/app/api/v1/loans/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { loans } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { loanSchema } from '@/lib/validations/loan'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(loans)
+    .where(and(eq(loans.userId, auth.userId), isNull(loans.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = loanSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  const [row] = await db.insert(loans).values({
+    userId: auth.userId,
+    name: d.name,
+    loanType: d.loanType,
+    principal: String(d.principal),
+    interestRate: String(d.interestRate),
+    tenureMonths: d.tenureMonths,
+    startDate: d.startDate,
+    emiAmount: String(d.emiAmount),
+    currency: d.currency,
+    outstandingBalance: String(d.principal),
+  }).returning()
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/debt-payoff')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/loans/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { loans } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(loans)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(loans.id, id), eq(loans.userId, auth.userId)))
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/debt-payoff')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Create `src/app/api/v1/loans/[id]/payment/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { loans, loanPayments } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { loanPaymentSchema } from '@/lib/validations/loan'
+import { revalidatePath } from 'next/cache'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = loanPaymentSchema.safeParse({ ...body, loanId: id })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const existing = await db.select().from(loans)
+    .where(and(eq(loans.id, id), eq(loans.userId, auth.userId), isNull(loans.deletedAt)))
+    .limit(1)
+  if (!existing.length) return NextResponse.json({ error: 'Loan not found' }, { status: 404 })
+
+  const d = parsed.data
+  const [payment] = await db.insert(loanPayments).values({
+    loanId: id,
+    date: d.date,
+    amount: String(d.amount),
+    principalComponent: d.principalComponent != null ? String(d.principalComponent) : null,
+    interestComponent: d.interestComponent != null ? String(d.interestComponent) : null,
+    status: d.status,
+  }).returning()
+
+  const loan = existing[0]
+  const newBalance = Math.max(0, Number(loan.outstandingBalance ?? loan.principal) - (d.principalComponent ?? 0))
+  await db.update(loans)
+    .set({ outstandingBalance: String(newBalance), updatedAt: new Date() })
+    .where(and(eq(loans.id, id), eq(loans.userId, auth.userId)))
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/debt-payoff')
+  return NextResponse.json(payment, { status: 201 })
+}
+```
+
+**Step 4: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/v1/loans/route.ts src/app/api/v1/loans/[id]/route.ts src/app/api/v1/loans/[id]/payment/route.ts
+git commit -m "feat(api): add /api/v1/loans GET, POST, DELETE and payment"
+```
+
+---
+
+## Task 9: Insurance endpoints
+
+**Files:**
+- Create: `src/app/api/v1/insurance/route.ts`
+- Create: `src/app/api/v1/insurance/[id]/route.ts`
+- Create: `src/app/api/v1/insurance/[id]/payment/route.ts`
+
+**Step 1: Create `src/app/api/v1/insurance/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { insurancePolicies } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { insuranceSchema } from '@/lib/validations/insurance'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(insurancePolicies)
+    .where(and(eq(insurancePolicies.userId, auth.userId), isNull(insurancePolicies.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = insuranceSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  const [row] = await db.insert(insurancePolicies).values({
+    userId: auth.userId,
+    name: d.name,
+    provider: d.provider || null,
+    policyType: d.policyType,
+    premiumAmount: String(d.premiumAmount),
+    premiumFrequency: d.premiumFrequency,
+    coverageAmount: d.coverageAmount != null ? String(d.coverageAmount) : null,
+    currency: d.currency,
+    startDate: d.startDate,
+    endDate: d.endDate || null,
+    renewalDate: d.renewalDate || null,
+    nominee: d.nominee || null,
+    notes: d.notes || null,
+  }).returning()
+
+  revalidatePath('/insurance')
+  revalidatePath('/dashboard')
+  return NextResponse.json(row, { status: 201 })
+}
+```
+
+**Step 2: Create `src/app/api/v1/insurance/[id]/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { insurancePolicies } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(insurancePolicies)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(insurancePolicies.id, id), eq(insurancePolicies.userId, auth.userId)))
+
+  revalidatePath('/insurance')
+  revalidatePath('/dashboard')
+  return NextResponse.json({ success: true })
+}
+```
+
+**Step 3: Create `src/app/api/v1/insurance/[id]/payment/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { insurancePolicies, insurancePayments } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { insurancePaymentSchema } from '@/lib/validations/insurance'
+import { revalidatePath } from 'next/cache'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = insurancePaymentSchema.safeParse({ ...body, policyId: id })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const existing = await db.select().from(insurancePolicies)
+    .where(and(eq(insurancePolicies.id, id), eq(insurancePolicies.userId, auth.userId), isNull(insurancePolicies.deletedAt)))
+    .limit(1)
+  if (!existing.length) return NextResponse.json({ error: 'Policy not found' }, { status: 404 })
+
+  const d = parsed.data
+  const [payment] = await db.insert(insurancePayments).values({
+    policyId: id,
+    date: d.date,
+    amount: String(d.amount),
+    status: d.status,
+  }).returning()
+
+  revalidatePath('/insurance')
+  revalidatePath('/dashboard')
+  return NextResponse.json(payment, { status: 201 })
+}
+```
+
+**Step 4: Verify build**
+
+```bash
+pnpm build
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/v1/insurance/route.ts src/app/api/v1/insurance/[id]/route.ts src/app/api/v1/insurance/[id]/payment/route.ts
+git commit -m "feat(api): add /api/v1/insurance GET, POST, DELETE and payment"
+```
+
+---
+
+## Task 10: Push branch and open PR
+
+**Step 1: Final build check**
+
+```bash
+pnpm build
+```
+
+Expected: zero errors, all routes compile.
+
+**Step 2: Push branch**
+
+```bash
+git push -u origin feat/rest-api-v1
+```
+
+**Step 3: Open PR**
+
+```bash
+gh pr create \
+  --title "feat: add /api/v1 REST layer for agent access" \
+  --body "Adds a session-authenticated REST API at /api/v1/ covering all entities.
+
+## Auth flow
+1. GET /api/auth/csrf → csrfToken + cookie
+2. POST /api/auth/callback/credentials with email/password/csrfToken → session cookie
+3. Use session cookie on all /api/v1/* requests
+
+## Endpoints
+- GET/POST /api/v1/accounts, DELETE /api/v1/accounts/[id]
+- GET/POST /api/v1/categories, DELETE /api/v1/categories/[id]
+- GET/POST /api/v1/transactions, DELETE /api/v1/transactions/[id]
+- GET/POST /api/v1/budgets, DELETE /api/v1/budgets/[id]
+- GET/POST /api/v1/goals, DELETE /api/v1/goals/[id], POST /api/v1/goals/[id]/contribute
+- GET/POST /api/v1/investments, DELETE /api/v1/investments/[id], PATCH /api/v1/investments/[id]/price
+- GET/POST /api/v1/loans, DELETE /api/v1/loans/[id], POST /api/v1/loans/[id]/payment
+- GET/POST /api/v1/insurance, DELETE /api/v1/insurance/[id], POST /api/v1/insurance/[id]/payment
+
+All routes accept/return JSON. All ownership guards match the existing server action logic.
+No new DB tables or migrations required." \
+  --base main
+```
+
+---
+
+## Complete API Reference (for agent skill)
+
+### Authentication
+
+```bash
+# 1. Get CSRF token
+curl https://money.shenthar.me/api/auth/csrf
+# → {"csrfToken":"<token>"}  + Set-Cookie: authjs.csrf-token=...
+
+# 2. Sign in (replace TOKEN and COOKIE)
+curl -X POST https://money.shenthar.me/api/auth/callback/credentials \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "Cookie: authjs.csrf-token=<csrf-cookie>" \
+  -d "email=user@example.com&password=secret&csrfToken=TOKEN&callbackUrl=https%3A%2F%2Fmoney.shenthar.me%2Fdashboard&redirect=false&json=true"
+# → Set-Cookie: authjs.session-token=...
+
+# All subsequent requests:
+-H "Cookie: authjs.session-token=<session-token>"
+```
+
+### Accounts
+```
+GET    /api/v1/accounts
+POST   /api/v1/accounts          { name, type: bank|wallet|cash|savings, currency }
+DELETE /api/v1/accounts/:id
+```
+
+### Categories
+```
+GET    /api/v1/categories
+POST   /api/v1/categories         { name, type: income|expense, color? }
+DELETE /api/v1/categories/:id
+```
+
+### Transactions
+```
+GET    /api/v1/transactions       ?type=&accountId=&from=YYYY-MM-DD&to=YYYY-MM-DD&limit=
+POST   /api/v1/transactions       { accountId, type: income|expense, amount, currency, categoryId?, note?, date: YYYY-MM-DD, isRecurring? }
+DELETE /api/v1/transactions/:id
+```
+
+### Budgets
+```
+GET    /api/v1/budgets
+POST   /api/v1/budgets            { name, amount, currency, periodType: monthly|weekly, startDate, categoryId?, endDate? }
+DELETE /api/v1/budgets/:id
+```
+
+### Goals
+```
+GET    /api/v1/goals
+POST   /api/v1/goals              { name, targetAmount, currency, description?, linkedAccountId?, deadline? }
+POST   /api/v1/goals/:id/contribute  { amount }
+DELETE /api/v1/goals/:id
+```
+
+### Investments
+```
+GET    /api/v1/investments
+POST   /api/v1/investments        { name, assetType: stock|mf|crypto|fd|ppf|nps|gold|silver|real_estate|savings|other, currency, quantity?, buyPrice?, currentPrice?, maturityDate?, interestRate? }
+PATCH  /api/v1/investments/:id/price  { currentPrice }
+DELETE /api/v1/investments/:id
+```
+
+### Loans
+```
+GET    /api/v1/loans
+POST   /api/v1/loans              { name, loanType: home|personal|vehicle|education|other, principal, interestRate, tenureMonths, startDate, emiAmount, currency }
+POST   /api/v1/loans/:id/payment  { date, amount, status: scheduled|paid|missed|partial, principalComponent?, interestComponent? }
+DELETE /api/v1/loans/:id
+```
+
+### Insurance
+```
+GET    /api/v1/insurance
+POST   /api/v1/insurance          { name, policyType: life|health|vehicle|property|term|other, premiumAmount, premiumFrequency: monthly|quarterly|annual, currency, startDate, provider?, coverageAmount?, endDate?, renewalDate?, nominee?, notes? }
+POST   /api/v1/insurance/:id/payment  { date, amount, status: paid|due|missed }
+DELETE /api/v1/insurance/:id
+```

--- a/src/app/api/v1/accounts/[id]/route.ts
+++ b/src/app/api/v1/accounts/[id]/route.ts
@@ -21,5 +21,6 @@ export async function DELETE(
   revalidatePath('/dashboard')
   revalidatePath('/transactions')
   revalidatePath('/networth')
+  revalidatePath('/reports/cash-flow')
   return NextResponse.json({ success: true })
 }

--- a/src/app/api/v1/accounts/[id]/route.ts
+++ b/src/app/api/v1/accounts/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { accounts } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(accounts)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(accounts.id, id), eq(accounts.userId, auth.userId)))
+
+  revalidatePath('/settings/accounts')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/networth')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/accounts/route.ts
+++ b/src/app/api/v1/accounts/route.ts
@@ -40,5 +40,6 @@ export async function POST(req: NextRequest) {
   revalidatePath('/dashboard')
   revalidatePath('/transactions')
   revalidatePath('/networth')
+  revalidatePath('/reports/cash-flow')
   return NextResponse.json(row, { status: 201 })
 }

--- a/src/app/api/v1/accounts/route.ts
+++ b/src/app/api/v1/accounts/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { accounts } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(['bank', 'wallet', 'cash', 'savings']),
+  currency: z.string().length(3),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(accounts)
+    .where(and(eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const [row] = await db.insert(accounts)
+    .values({ ...parsed.data, userId: auth.userId })
+    .returning()
+
+  revalidatePath('/settings/accounts')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/networth')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/budgets/[id]/route.ts
+++ b/src/app/api/v1/budgets/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { budgets } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(budgets)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(budgets.id, id), eq(budgets.userId, auth.userId)))
+
+  revalidatePath('/budgets')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/budget-vs-actual')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/budgets/route.ts
+++ b/src/app/api/v1/budgets/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { budgets, categories } from '@/lib/db/schema'
+import { eq, and, isNull, or } from 'drizzle-orm'
+import { budgetSchema } from '@/lib/validations/budget'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(budgets)
+    .where(and(eq(budgets.userId, auth.userId), isNull(budgets.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = budgetSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+    categoryId: body.categoryId || undefined,
+    endDate: body.endDate || undefined,
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  if (d.categoryId) {
+    const catCheck = await db.query.categories.findFirst({
+      where: and(eq(categories.id, d.categoryId), isNull(categories.deletedAt), or(eq(categories.userId, auth.userId), isNull(categories.userId))),
+    })
+    if (!catCheck) return NextResponse.json({ error: 'Category not found or not yours' }, { status: 400 })
+  }
+
+  const [row] = await db.insert(budgets).values({
+    userId: auth.userId,
+    name: d.name,
+    categoryId: d.categoryId || null,
+    amount: String(d.amount),
+    currency: d.currency,
+    periodType: d.periodType,
+    startDate: d.startDate,
+    endDate: d.endDate || null,
+  }).returning()
+
+  revalidatePath('/budgets')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/budget-vs-actual')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/categories/[id]/route.ts
+++ b/src/app/api/v1/categories/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { categories } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(categories)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(categories.id, id), eq(categories.userId, auth.userId)))
+
+  revalidatePath('/settings/categories')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/budgets')
+  revalidatePath('/reports/category-breakdown')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/categories/route.ts
+++ b/src/app/api/v1/categories/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { categories } from '@/lib/db/schema'
+import { eq, and, isNull, or } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  type: z.enum(['income', 'expense']),
+  color: z.string().optional(),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(categories)
+    .where(and(
+      isNull(categories.deletedAt),
+      or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+    ))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const [row] = await db.insert(categories)
+    .values({ ...parsed.data, userId: auth.userId })
+    .returning()
+
+  revalidatePath('/settings/categories')
+  revalidatePath('/dashboard')
+  revalidatePath('/transactions')
+  revalidatePath('/budgets')
+  revalidatePath('/reports/category-breakdown')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/goals/[id]/contribute/route.ts
+++ b/src/app/api/v1/goals/[id]/contribute/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { savingsGoals } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const schema = z.object({ amount: z.number().positive() })
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const { amount } = parsed.data
+
+  const rows = await db.select().from(savingsGoals)
+    .where(and(eq(savingsGoals.id, id), eq(savingsGoals.userId, auth.userId), isNull(savingsGoals.deletedAt)))
+    .limit(1)
+  if (!rows.length) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const goal = rows[0]
+  if (goal.status === 'achieved') return NextResponse.json({ error: 'Goal already achieved' }, { status: 400 })
+
+  const newAmount = Number(goal.currentAmount) + amount
+  const isAchieved = newAmount >= Number(goal.targetAmount)
+
+  const [row] = await db.update(savingsGoals)
+    .set({ currentAmount: String(newAmount), status: isAchieved ? 'achieved' : 'active', updatedAt: new Date() })
+    .where(eq(savingsGoals.id, id))
+    .returning()
+
+  revalidatePath('/budgets/goals')
+  revalidatePath('/dashboard')
+  return NextResponse.json(row)
+}

--- a/src/app/api/v1/goals/[id]/route.ts
+++ b/src/app/api/v1/goals/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { savingsGoals } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(savingsGoals)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(savingsGoals.id, id), eq(savingsGoals.userId, auth.userId)))
+
+  revalidatePath('/budgets/goals')
+  revalidatePath('/dashboard')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/goals/route.ts
+++ b/src/app/api/v1/goals/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { savingsGoals, accounts } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { savingsGoalSchema } from '@/lib/validations/budget'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(savingsGoals)
+    .where(and(eq(savingsGoals.userId, auth.userId), isNull(savingsGoals.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = savingsGoalSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+    description: body.description || undefined,
+    linkedAccountId: body.linkedAccountId || undefined,
+    deadline: body.deadline || undefined,
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  if (d.linkedAccountId) {
+    const acctCheck = await db.query.accounts.findFirst({
+      where: and(eq(accounts.id, d.linkedAccountId), eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)),
+    })
+    if (!acctCheck) return NextResponse.json({ error: 'Account not found or not yours' }, { status: 400 })
+  }
+
+  const [row] = await db.insert(savingsGoals).values({
+    userId: auth.userId,
+    name: d.name,
+    description: d.description || null,
+    targetAmount: String(d.targetAmount),
+    currency: d.currency,
+    linkedAccountId: d.linkedAccountId || null,
+    deadline: d.deadline || null,
+  }).returning()
+
+  revalidatePath('/budgets/goals')
+  revalidatePath('/dashboard')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/insurance/[id]/payment/route.ts
+++ b/src/app/api/v1/insurance/[id]/payment/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { insurancePolicies, insurancePayments } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { insurancePaymentSchema } from '@/lib/validations/insurance'
+import { revalidatePath } from 'next/cache'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = insurancePaymentSchema.safeParse({ ...body, policyId: id })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const existing = await db.select().from(insurancePolicies)
+    .where(and(eq(insurancePolicies.id, id), eq(insurancePolicies.userId, auth.userId), isNull(insurancePolicies.deletedAt)))
+    .limit(1)
+  if (!existing.length) return NextResponse.json({ error: 'Policy not found' }, { status: 404 })
+
+  const d = parsed.data
+  const [payment] = await db.insert(insurancePayments).values({
+    policyId: id,
+    date: d.date,
+    amount: String(d.amount),
+    status: d.status,
+  }).returning()
+
+  revalidatePath('/insurance')
+  revalidatePath('/dashboard')
+  return NextResponse.json(payment, { status: 201 })
+}

--- a/src/app/api/v1/insurance/[id]/route.ts
+++ b/src/app/api/v1/insurance/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { insurancePolicies } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(insurancePolicies)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(insurancePolicies.id, id), eq(insurancePolicies.userId, auth.userId)))
+
+  revalidatePath('/insurance')
+  revalidatePath('/dashboard')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/insurance/route.ts
+++ b/src/app/api/v1/insurance/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { insurancePolicies } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { insuranceSchema } from '@/lib/validations/insurance'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(insurancePolicies)
+    .where(and(eq(insurancePolicies.userId, auth.userId), isNull(insurancePolicies.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = insuranceSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  const [row] = await db.insert(insurancePolicies).values({
+    userId: auth.userId,
+    name: d.name,
+    provider: d.provider || null,
+    policyType: d.policyType,
+    premiumAmount: String(d.premiumAmount),
+    premiumFrequency: d.premiumFrequency,
+    coverageAmount: d.coverageAmount != null ? String(d.coverageAmount) : null,
+    currency: d.currency,
+    startDate: d.startDate,
+    endDate: d.endDate || null,
+    renewalDate: d.renewalDate || null,
+    nominee: d.nominee || null,
+    notes: d.notes || null,
+  }).returning()
+
+  revalidatePath('/insurance')
+  revalidatePath('/dashboard')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/investments/[id]/price/route.ts
+++ b/src/app/api/v1/investments/[id]/price/route.ts
@@ -21,9 +21,7 @@ export async function PATCH(
   if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
 
   const { currentPrice } = parsed.data
-  if (!Number.isFinite(currentPrice) || currentPrice < 0) {
-    return NextResponse.json({ error: 'Price must be a non-negative number' }, { status: 400 })
-  }
+  // z.number().min(0) in schema already rejects negatives and non-numbers
 
   const [row] = await db.update(investments)
     .set({ currentPrice: String(currentPrice), currentPriceUpdatedAt: new Date(), updatedAt: new Date() })

--- a/src/app/api/v1/investments/[id]/price/route.ts
+++ b/src/app/api/v1/investments/[id]/price/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { investments } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { z } from 'zod'
+import { revalidatePath } from 'next/cache'
+
+const schema = z.object({ currentPrice: z.number().min(0) })
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const { currentPrice } = parsed.data
+  if (!Number.isFinite(currentPrice) || currentPrice < 0) {
+    return NextResponse.json({ error: 'Price must be a non-negative number' }, { status: 400 })
+  }
+
+  const [row] = await db.update(investments)
+    .set({ currentPrice: String(currentPrice), currentPriceUpdatedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(investments.id, id), eq(investments.userId, auth.userId)))
+    .returning()
+
+  revalidatePath('/investments')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/investment-returns')
+  return NextResponse.json(row)
+}

--- a/src/app/api/v1/investments/[id]/route.ts
+++ b/src/app/api/v1/investments/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { investments } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(investments)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(investments.id, id), eq(investments.userId, auth.userId)))
+
+  revalidatePath('/investments')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/investment-returns')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/investments/route.ts
+++ b/src/app/api/v1/investments/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { investments } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { investmentSchema } from '@/lib/validations/investment'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(investments)
+    .where(and(eq(investments.userId, auth.userId), isNull(investments.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = investmentSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const data = parsed.data
+  const [row] = await db.insert(investments).values({
+    userId: auth.userId,
+    name: data.name,
+    assetType: data.assetType,
+    currency: data.currency,
+    quantity: data.quantity != null ? String(data.quantity) : null,
+    buyPrice: data.buyPrice != null ? String(data.buyPrice) : null,
+    currentPrice: data.currentPrice != null ? String(data.currentPrice) : null,
+    maturityDate: data.maturityDate || null,
+    interestRate: data.interestRate != null ? String(data.interestRate) : null,
+  }).returning()
+
+  revalidatePath('/investments')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/investment-returns')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/loans/[id]/payment/route.ts
+++ b/src/app/api/v1/loans/[id]/payment/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { loans, loanPayments } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { loanPaymentSchema } from '@/lib/validations/loan'
+import { revalidatePath } from 'next/cache'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const body = await req.json()
+  const parsed = loanPaymentSchema.safeParse({ ...body, loanId: id })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const existing = await db.select().from(loans)
+    .where(and(eq(loans.id, id), eq(loans.userId, auth.userId), isNull(loans.deletedAt)))
+    .limit(1)
+  if (!existing.length) return NextResponse.json({ error: 'Loan not found' }, { status: 404 })
+
+  const d = parsed.data
+  const [payment] = await db.insert(loanPayments).values({
+    loanId: id,
+    date: d.date,
+    amount: String(d.amount),
+    principalComponent: d.principalComponent != null ? String(d.principalComponent) : null,
+    interestComponent: d.interestComponent != null ? String(d.interestComponent) : null,
+    status: d.status,
+  }).returning()
+
+  const loan = existing[0]
+  const newBalance = Math.max(0, Number(loan.outstandingBalance ?? loan.principal) - (d.principalComponent ?? 0))
+  await db.update(loans)
+    .set({ outstandingBalance: String(newBalance), updatedAt: new Date() })
+    .where(and(eq(loans.id, id), eq(loans.userId, auth.userId)))
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/debt-payoff')
+  return NextResponse.json(payment, { status: 201 })
+}

--- a/src/app/api/v1/loans/[id]/route.ts
+++ b/src/app/api/v1/loans/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { loans } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(loans)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(loans.id, id), eq(loans.userId, auth.userId)))
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/debt-payoff')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/loans/route.ts
+++ b/src/app/api/v1/loans/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { loans } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { loanSchema } from '@/lib/validations/loan'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(loans)
+    .where(and(eq(loans.userId, auth.userId), isNull(loans.deletedAt)))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = loanSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+  const [row] = await db.insert(loans).values({
+    userId: auth.userId,
+    name: d.name,
+    loanType: d.loanType,
+    principal: String(d.principal),
+    interestRate: String(d.interestRate),
+    tenureMonths: d.tenureMonths,
+    startDate: d.startDate,
+    emiAmount: String(d.emiAmount),
+    currency: d.currency,
+    outstandingBalance: String(d.principal),
+  }).returning()
+
+  revalidatePath('/loans')
+  revalidatePath('/dashboard')
+  revalidatePath('/networth')
+  revalidatePath('/reports/debt-payoff')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/app/api/v1/transactions/[id]/route.ts
+++ b/src/app/api/v1/transactions/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { transactions } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  await db.update(transactions)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(transactions.id, id), eq(transactions.userId, auth.userId)))
+
+  revalidatePath('/transactions')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/cash-flow')
+  revalidatePath('/reports/category-breakdown')
+  revalidatePath('/reports/budget-vs-actual')
+  revalidatePath('/networth')
+  revalidatePath('/budgets')
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
   const accountId = searchParams.get('accountId')
   const from = searchParams.get('from')
   const to = searchParams.get('to')
-  const limit = Math.min(Number(searchParams.get('limit') ?? 100), 500)
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '100', 10) || 100, 500)
 
   const conditions: SQL[] = [
     eq(transactions.userId, auth.userId),
@@ -42,7 +42,6 @@ export async function GET(req: NextRequest) {
     .where(and(...conditions as [SQL, ...SQL[]]))
     .limit(limit)
     .orderBy(transactions.date)
-
   return NextResponse.json(rows)
 }
 

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { transactions, users, accounts, categories } from '@/lib/db/schema'
+import { eq, and, isNull, or, gte, lte, SQL } from 'drizzle-orm'
+import { z } from 'zod'
+import { getRate } from '@/lib/utils/currency'
+import { revalidatePath } from 'next/cache'
+
+const createSchema = z.object({
+  accountId: z.string().uuid(),
+  type: z.enum(['income', 'expense']),
+  amount: z.coerce.number().positive(),
+  currency: z.string().length(3),
+  categoryId: z.string().uuid().optional(),
+  note: z.string().max(500).optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  isRecurring: z.coerce.boolean().default(false),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { searchParams } = new URL(req.url)
+  const type = searchParams.get('type')
+  const accountId = searchParams.get('accountId')
+  const from = searchParams.get('from')
+  const to = searchParams.get('to')
+  const limit = Math.min(Number(searchParams.get('limit') ?? 100), 500)
+
+  const conditions: SQL[] = [
+    eq(transactions.userId, auth.userId),
+    isNull(transactions.deletedAt),
+  ]
+  if (type) conditions.push(eq(transactions.type, type as 'income' | 'expense'))
+  if (accountId) conditions.push(eq(transactions.accountId, accountId))
+  if (from) conditions.push(gte(transactions.date, from))
+  if (to) conditions.push(lte(transactions.date, to))
+
+  const rows = await db.select().from(transactions)
+    .where(and(...conditions as [SQL, ...SQL[]]))
+    .limit(limit)
+    .orderBy(transactions.date)
+
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse({
+    ...body,
+    currency: String(body.currency ?? '').toUpperCase(),
+  })
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const d = parsed.data
+
+  const accountCheck = await db.query.accounts.findFirst({
+    where: and(eq(accounts.id, d.accountId), eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)),
+  })
+  if (!accountCheck) return NextResponse.json({ error: 'Account not found or not yours' }, { status: 400 })
+
+  if (d.categoryId) {
+    const catCheck = await db.query.categories.findFirst({
+      where: and(
+        eq(categories.id, d.categoryId),
+        isNull(categories.deletedAt),
+        or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+      ),
+    })
+    if (!catCheck) return NextResponse.json({ error: 'Category not found or not yours' }, { status: 400 })
+  }
+
+  const user = await db.query.users.findFirst({ where: eq(users.id, auth.userId) })
+  const baseCurrency = user?.defaultCurrency ?? 'INR'
+  const rate = await getRate(d.currency, baseCurrency)
+
+  const [row] = await db.insert(transactions).values({
+    ...d,
+    userId: auth.userId,
+    amount: String(d.amount),
+    convertedAmount: String(d.amount * rate),
+    baseCurrency,
+  }).returning()
+
+  revalidatePath('/transactions')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/cash-flow')
+  revalidatePath('/reports/category-breakdown')
+  revalidatePath('/reports/budget-vs-actual')
+  revalidatePath('/networth')
+  revalidatePath('/budgets')
+  return NextResponse.json(row, { status: 201 })
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,12 @@
+import { auth } from '@/lib/auth/config'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function resolveSession(
+  req: NextRequest,
+): Promise<{ userId: string } | NextResponse> {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return { userId: session.user.id }
+}


### PR DESCRIPTION
## Summary

Adds a session-authenticated REST API at `/api/v1/` so AI agents (and other programmatic clients) can perform full CRUD on all entities.

No new DB tables or migrations required — reuses existing Drizzle schema and validation logic.

## Auth flow

```
# 1. Get CSRF token
GET /api/auth/csrf  →  { csrfToken } + Set-Cookie: authjs.csrf-token

# 2. Sign in
POST /api/auth/callback/credentials
  email=...&password=...&csrfToken=...&callbackUrl=...&redirect=false&json=true
  →  Set-Cookie: authjs.session-token

# 3. Use session cookie on all /api/v1/* requests
Cookie: authjs.session-token=<token>
```

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET/POST | `/api/v1/accounts` | List / create accounts |
| DELETE | `/api/v1/accounts/[id]` | Soft-delete account |
| GET/POST | `/api/v1/categories` | List (user + system) / create categories |
| DELETE | `/api/v1/categories/[id]` | Soft-delete category |
| GET/POST | `/api/v1/transactions` | List (with filters) / create transactions |
| DELETE | `/api/v1/transactions/[id]` | Soft-delete transaction |
| GET/POST | `/api/v1/budgets` | List / create budgets |
| DELETE | `/api/v1/budgets/[id]` | Soft-delete budget |
| GET/POST | `/api/v1/goals` | List / create savings goals |
| POST | `/api/v1/goals/[id]/contribute` | Contribute amount to goal |
| DELETE | `/api/v1/goals/[id]` | Soft-delete goal |
| GET/POST | `/api/v1/investments` | List / create investments |
| PATCH | `/api/v1/investments/[id]/price` | Update current price |
| DELETE | `/api/v1/investments/[id]` | Soft-delete investment |
| GET/POST | `/api/v1/loans` | List / create loans |
| POST | `/api/v1/loans/[id]/payment` | Record loan payment |
| DELETE | `/api/v1/loans/[id]` | Soft-delete loan |
| GET/POST | `/api/v1/insurance` | List / create policies |
| POST | `/api/v1/insurance/[id]/payment` | Record premium payment |
| DELETE | `/api/v1/insurance/[id]` | Soft-delete policy |

## Transaction GET filters

`?type=income|expense`, `?accountId=`, `?from=YYYY-MM-DD`, `?to=YYYY-MM-DD`, `?limit=` (max 500, default 100)

## Ownership guards

All write endpoints validate that referenced entities (accountId, categoryId, linkedAccountId, loanId, policyId) belong to the authenticated user before writing. Matches the existing server action guards exactly.