### PR TITLE
feat(api): add GET /:id routes for all v1 entities

### DIFF
--- a/src/app/api/v1/accounts/[id]/route.ts
+++ b/src/app/api/v1/accounts/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { accounts } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.accounts.findFirst({
+    where: and(eq(accounts.id, id), eq(accounts.userId, auth.userId), isNull(accounts.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/budgets/[id]/route.ts
+++ b/src/app/api/v1/budgets/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { budgets } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.budgets.findFirst({
+    where: and(eq(budgets.id, id), eq(budgets.userId, auth.userId), isNull(budgets.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/categories/[id]/route.ts
+++ b/src/app/api/v1/categories/[id]/route.ts
@@ -2,8 +2,27 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { categories } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull, or } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.categories.findFirst({
+    where: and(
+      eq(categories.id, id),
+      isNull(categories.deletedAt),
+      or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+    ),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/goals/[id]/route.ts
+++ b/src/app/api/v1/goals/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { savingsGoals } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.savingsGoals.findFirst({
+    where: and(eq(savingsGoals.id, id), eq(savingsGoals.userId, auth.userId), isNull(savingsGoals.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/insurance/[id]/route.ts
+++ b/src/app/api/v1/insurance/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { insurancePolicies } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.insurancePolicies.findFirst({
+    where: and(eq(insurancePolicies.id, id), eq(insurancePolicies.userId, auth.userId), isNull(insurancePolicies.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/investments/[id]/route.ts
+++ b/src/app/api/v1/investments/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { investments } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.investments.findFirst({
+    where: and(eq(investments.id, id), eq(investments.userId, auth.userId), isNull(investments.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/loans/[id]/route.ts
+++ b/src/app/api/v1/loans/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { loans } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.loans.findFirst({
+    where: and(eq(loans.id, id), eq(loans.userId, auth.userId), isNull(loans.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/src/app/api/v1/transactions/[id]/route.ts
+++ b/src/app/api/v1/transactions/[id]/route.ts
@@ -2,8 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
 import { transactions } from '@/lib/db/schema'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, isNull } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { id } = await params
+  const row = await db.query.transactions.findFirst({
+    where: and(eq(transactions.id, id), eq(transactions.userId, auth.userId), isNull(transactions.deletedAt)),
+  })
+  if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(row)
+}
 
 export async function DELETE(
   req: NextRequest,


### PR DESCRIPTION
## Summary

Adds individual resource GET endpoints to all `/api/v1/` entity routes, fixing the 405 bug found during live API testing.

## New endpoints

| Method | Path |
|--------|------|
| GET | `/api/v1/accounts/:id` |
| GET | `/api/v1/categories/:id` |
| GET | `/api/v1/transactions/:id` |
| GET | `/api/v1/budgets/:id` |
| GET | `/api/v1/goals/:id` |
| GET | `/api/v1/investments/:id` |
| GET | `/api/v1/loans/:id` |
| GET | `/api/v1/insurance/:id` |

All return 200 with the resource JSON, or 404 `{"error":"Not found"}` if the resource doesn't exist or doesn't belong to the authenticated user. Soft-deleted resources also return 404.

## Notes

- Categories GET respects user-owned OR system (`userId IS NULL`) scope, matching the collection endpoint
- All other entities are scoped strictly to the authenticated user's `userId`