### PR TITLE
redesign: eliminate AI slop UI — flat layout, number-first, no nested cards

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -11,21 +11,17 @@ import {
 } from "@/lib/db/schema";
 import { and, desc, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { endOfMonth, format, startOfMonth, subDays } from "date-fns";
-import { Plus, ReceiptText, Settings, WalletCards } from "lucide-react";
+import { Plus } from "lucide-react";
 import { getBudgetPeriod } from "@/lib/utils/budgetPeriod";
 import { BudgetHealthBar } from "@/components/dashboard/BudgetHealthBar";
 import { UpcomingRecurring } from "@/components/dashboard/UpcomingRecurring";
 import { SpendingHeatmap } from "@/components/dashboard/SpendingHeatmap";
-
 import { CashFlowSummary } from "@/components/dashboard/CashFlowSummary";
-import { DashboardSections } from "@/components/dashboard/DashboardSections";
 import { NetworthCard } from "@/components/dashboard/NetworthCard";
 import { RecentTransactions } from "@/components/dashboard/RecentTransactions";
 import { UpcomingAlerts } from "@/components/dashboard/UpcomingAlerts";
 import {
   HeaderActionLink,
-  MetricCard,
-  PageHeader,
   PageShell,
   SetupChecklist,
 } from "@/components/shared/quiet-ledger";
@@ -106,7 +102,6 @@ export default async function DashboardPage() {
   const hasCategories = categoryList.length > 0;
   const hasTransactions = recentTxs.length > 0;
 
-  // New triage data fetches
   const budgetList = await db
     .select()
     .from(budgets)
@@ -164,106 +159,86 @@ export default async function DashboardPage() {
 
   return (
     <PageShell size="wide">
-      <PageHeader
-        eyebrow="Quiet Ledger"
-        title={`Good to see you, ${displayName}`}
-        description="Your private money home for cash flow, net worth, upcoming obligations, and daily activity."
-        action={
-          hasAccounts ? (
-            <HeaderActionLink href="/transactions">
-              <Plus className="h-4 w-4" />
-              Add transaction
-            </HeaderActionLink>
-          ) : (
-            <HeaderActionLink href="/settings/accounts">
-              <Plus className="h-4 w-4" />
-              Set up account
-            </HeaderActionLink>
-          )
-        }
-      >
-        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-          <span>{accountList.length} accounts</span>
-          <span>·</span>
-          <span>{monthlyTxs.length} this month</span>
-          <span>·</span>
-          <span>{baseCurrency} home currency</span>
+      {/* Header — date + name + action, no description filler */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground">
+            {format(now, "EEEE, d MMMM")}
+          </p>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">
+            {displayName}
+          </h1>
         </div>
-      </PageHeader>
-
-      <DashboardSections
-        setup={
-          <SetupChecklist
-            items={[
-              {
-                label: "Add your first account",
-                href: "/settings/accounts",
-                complete: hasAccounts,
-              },
-              {
-                label: "Review categories",
-                href: "/settings/categories",
-                complete: hasCategories,
-              },
-              {
-                label: "Record your first transaction",
-                href: "/transactions",
-                complete: hasTransactions,
-              },
-            ]}
-          />
-        }
-        snapshot={<NetworthCard {...networthData} currency={baseCurrency} />}
-        basics={
-          <div className="grid gap-3 md:grid-cols-3">
-            <MetricCard
-              label="Accounts"
-              value={accountList.length}
-              description="Places where money lives: bank, wallet, cash, or savings."
-              icon={WalletCards}
-              tone={hasAccounts ? "positive" : "warning"}
-              className="rounded-[1.5rem]"
-            />
-            <MetricCard
-              label="Categories"
-              value={categoryList.length}
-              description="Simple labels that make spending easier to understand."
-              icon={Settings}
-              tone={hasCategories ? "positive" : "warning"}
-              className="rounded-[1.5rem]"
-            />
-            <MetricCard
-              label="Recent entries"
-              value={recentTxs.length}
-              description="Latest activity captured in your private ledger."
-              icon={ReceiptText}
-              tone={hasTransactions ? "positive" : "neutral"}
-              className="rounded-[1.5rem]"
-            />
-          </div>
-        }
-        cashFlow={<CashFlowSummary transactions={monthlyTxs} currency={baseCurrency} />}
-        recent={<RecentTransactions transactions={recentTxs} />}
-        attention={<UpcomingAlerts loans={loanList} policies={policyList} />}
-      />
-
-      {/* Triage control tower sections */}
-      <div className="space-y-6 mt-5">
-        {budgetHealth.length > 0 && (
-          <section className="space-y-3">
-            <h2 className="text-sm font-bold uppercase tracking-wider text-muted-foreground">Budget health</h2>
-            <div className="space-y-2">
-              {budgetHealth.map(({ budget, spent, period }) => (
-                <BudgetHealthBar key={budget.id} budget={budget} spent={spent} period={period} />
-              ))}
-            </div>
-          </section>
+        {hasAccounts ? (
+          <HeaderActionLink href="/transactions">
+            <Plus className="h-4 w-4 mr-1" /> Add transaction
+          </HeaderActionLink>
+        ) : (
+          <HeaderActionLink href="/settings/accounts">
+            <Plus className="h-4 w-4 mr-1" /> Add account
+          </HeaderActionLink>
         )}
-
-        <UpcomingRecurring transactions={recurringTxs} />
-
-        <SpendingHeatmap dailySpend={dailySpend} currency={baseCurrency} />
       </div>
+
+      {/* Setup checklist — only when incomplete */}
+      {(!hasAccounts || !hasCategories || !hasTransactions) && (
+        <SetupChecklist
+          items={[
+            {
+              label: "Add your first account",
+              href: "/settings/accounts",
+              complete: hasAccounts,
+            },
+            {
+              label: "Review categories",
+              href: "/settings/categories",
+              complete: hasCategories,
+            },
+            {
+              label: "Record your first transaction",
+              href: "/transactions",
+              complete: hasTransactions,
+            },
+          ]}
+        />
+      )}
+
+      {/* Net worth hero */}
+      <NetworthCard {...networthData} currency={baseCurrency} />
+
+      {/* Budget health */}
+      {budgetHealth.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-muted-foreground">
+            Budgets
+          </h2>
+          <div className="space-y-2">
+            {budgetHealth.map(({ budget, spent, period }) => (
+              <BudgetHealthBar
+                key={budget.id}
+                budget={budget}
+                spent={spent}
+                period={period}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Upcoming recurring */}
+      <UpcomingRecurring transactions={recurringTxs} />
+
+      {/* Cash flow + recent side by side on desktop */}
+      <div className="grid gap-5 lg:grid-cols-[1fr_1.2fr]">
+        <CashFlowSummary transactions={monthlyTxs} currency={baseCurrency} />
+        <RecentTransactions transactions={recentTxs} />
+      </div>
+
+      {/* Spending heatmap */}
+      <SpendingHeatmap dailySpend={dailySpend} currency={baseCurrency} />
+
+      {/* Loans / insurance alerts — only if non-empty */}
+      <UpcomingAlerts loans={loanList} policies={policyList} />
     </PageShell>
   );
 }

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link'
-import { WalletCards, Banknote, PiggyBank, Wallet } from 'lucide-react'
 import { formatCurrency } from '@/lib/utils/format'
 import { cn } from '@/lib/utils'
 import type { Account } from '@/lib/db/schema'
@@ -8,35 +7,28 @@ interface Props {
   account: Account & { balance: number }
 }
 
-const TYPE_STYLES: Record<string, { bg: string; text: string; Icon: React.ComponentType<{ className?: string }> }> = {
-  bank: { bg: 'bg-sky-100 dark:bg-sky-950', text: 'text-sky-700 dark:text-sky-300', Icon: WalletCards },
-  wallet: { bg: 'bg-violet-100 dark:bg-violet-950', text: 'text-violet-700 dark:text-violet-300', Icon: Wallet },
-  cash: { bg: 'bg-amber-100 dark:bg-amber-950', text: 'text-amber-700 dark:text-amber-300', Icon: Banknote },
-  savings: { bg: 'bg-emerald-100 dark:bg-emerald-950', text: 'text-emerald-700 dark:text-emerald-300', Icon: PiggyBank },
+const TYPE_DOT: Record<string, string> = {
+  bank: 'bg-sky-500',
+  wallet: 'bg-violet-500',
+  cash: 'bg-amber-500',
+  savings: 'bg-emerald-500',
 }
 
 export function AccountCard({ account }: Props) {
-  const style = TYPE_STYLES[account.type] ?? TYPE_STYLES.bank
-  const Icon = style.Icon
-
   return (
-    <Link
-      href={`/accounts/${account.id}`}
-      className="group rounded-3xl border bg-card p-5 shadow-sm hover:shadow-md transition-all space-y-4 block"
-    >
-      <div className="flex items-start justify-between">
-        <div className={cn('flex size-11 items-center justify-center rounded-2xl', style.bg, style.text)}>
-          <Icon className="size-5" />
-        </div>
-        <span className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">{account.type}</span>
+    <Link href={`/accounts/${account.id}`}
+      className="group block rounded-2xl border bg-card p-5 hover:shadow-md transition-shadow">
+      <div className="flex items-center gap-2 mb-3">
+        <span className={cn('size-2 rounded-full', TYPE_DOT[account.type] ?? 'bg-muted-foreground')} />
+        <span className="text-xs font-medium text-muted-foreground capitalize">{account.type}</span>
       </div>
-      <div>
-        <p className="text-base font-semibold">{account.name}</p>
-        <p className={cn('text-2xl font-bold mt-1 tabular-nums', account.balance < 0 ? 'text-rose-600' : 'text-foreground')}>
-          {formatCurrency(account.balance, account.currency)}
-        </p>
-        <p className="text-xs text-muted-foreground mt-1">{account.currency}</p>
-      </div>
+      <p className="text-sm font-semibold truncate">{account.name}</p>
+      <p className={cn(
+        'text-3xl font-bold tabular-nums tracking-tight mt-1',
+        account.balance < 0 ? 'text-rose-600' : 'text-foreground'
+      )}>
+        {formatCurrency(account.balance, account.currency)}
+      </p>
     </Link>
   )
 }

--- a/src/components/budgets/BudgetCard.tsx
+++ b/src/components/budgets/BudgetCard.tsx
@@ -1,149 +1,102 @@
 'use client'
+import Link from 'next/link'
 import { useTransition } from 'react'
-import { Gauge, Trash2, WalletCards } from 'lucide-react'
-
+import { Trash2 } from 'lucide-react'
 import { deleteBudget } from '@/app/actions/budgets'
-import {
-  AmountBox,
-  FinancialAmount,
-  IconBadge,
-  ProgressMeter,
-  StatusPill,
-  TonalWidget,
-} from '@/components/shared/quiet-ledger'
+import { formatCurrency } from '@/lib/utils/format'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
+  Dialog, DialogClose, DialogContent, DialogDescription,
+  DialogFooter, DialogHeader, DialogTitle, DialogTrigger,
 } from '@/components/ui/dialog'
 import type { Budget } from '@/lib/db/schema'
-import type { getDailyAllowance } from '@/lib/utils/budgetPeriod'
-
-type Allowance = ReturnType<typeof getDailyAllowance>
 
 interface Props {
   budget: Budget
   spent: number
-  allowance?: Allowance
+  period?: { progressPct: number; daysRemaining: number; start: Date; end: Date }
+  allowance?: { dailyAllowance: number; isOverspent: boolean; overspentBy: number; daysRemaining: number }
 }
 
-export function BudgetCard({ budget, spent, allowance }: Props) {
+export function BudgetCard({ budget, spent, period, allowance }: Props) {
   const [isPending, startTransition] = useTransition()
-
   const total = Number(budget.amount)
-  const pct = total > 0 ? Math.min(100, (spent / total) * 100) : 0
-  const remaining = total - spent
+  const spentPct = total > 0 ? Math.min(100, (spent / total) * 100) : 0
+  const timePct = period?.progressPct ?? 50
+  const isOver = spentPct >= 100
+  const isBehind = spentPct > timePct + 10
 
-  const tone = pct >= 100 ? 'negative' : pct >= 80 ? 'warning' : 'positive'
-  const status = pct >= 100 ? 'Over plan' : pct >= 80 ? 'Watch' : 'On track'
-
-  function handleDelete() {
-    startTransition(async () => {
-      await deleteBudget(budget.id)
-    })
-  }
+  const barColor = isOver ? 'bg-rose-500' : isBehind ? 'bg-amber-400' : 'bg-primary'
 
   return (
-    <TonalWidget tone="budget" className="space-y-5">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-3">
-          <IconBadge icon={Gauge} tone="budget" className="size-12 rounded-[1.35rem]" />
-          <div className="min-w-0 space-y-1">
-          <p className="truncate text-base font-semibold">{budget.name}</p>
-          <div className="flex flex-wrap gap-2">
-            <StatusPill className="capitalize">{budget.periodType}</StatusPill>
-            <StatusPill tone={tone}>{status}</StatusPill>
-          </div>
-          </div>
+    <div className="rounded-2xl border bg-card p-4 space-y-3">
+      {/* Name + amount */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-semibold text-base truncate">{budget.name}</p>
+          <p className="text-xs text-muted-foreground capitalize mt-0.5">{budget.periodType}</p>
         </div>
-        <span className="shrink-0 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
-          {budget.currency}
-        </span>
-      </div>
-
-      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5">
-        <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-          Planned
-        </p>
-        <p className="financial-display mt-2 text-3xl font-bold">
-          <FinancialAmount amount={total} currency={budget.currency} sign="never" />
+        <p className="text-sm font-bold tabular-nums shrink-0 text-muted-foreground">
+          {formatCurrency(total, budget.currency)}
         </p>
       </div>
 
-      <div>
-        <ProgressMeter value={spent} max={total} tone={tone} label="Spent so far" />
-        <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
-          <AmountBox
-            label="Spent"
-            amount={spent}
-            currency={budget.currency}
-            icon={WalletCards}
-            tone={tone}
+      {/* Spent number */}
+      <p className={cn('text-2xl font-bold tabular-nums', isOver ? 'text-rose-600' : 'text-foreground')}>
+        {formatCurrency(spent, budget.currency)}
+        <span className="text-sm font-normal text-muted-foreground ml-1">spent</span>
+      </p>
+
+      {/* Progress bar with Today marker */}
+      <div className="relative h-3 w-full rounded-full bg-muted overflow-visible">
+        <div className={cn('h-full rounded-full', barColor)} style={{ width: `${spentPct}%` }} />
+        {period && (
+          <div
+            className="absolute top-1/2 -translate-y-1/2 h-5 w-0.5 rounded-full bg-foreground/50"
+            style={{ left: `${Math.min(98, timePct)}%` }}
           />
-          <AmountBox
-            label={remaining >= 0 ? 'Left' : 'Over'}
-            amount={Math.abs(remaining)}
-            currency={budget.currency}
-            icon={WalletCards}
-            tone={remaining >= 0 ? 'positive' : 'negative'}
-          />
-        </div>
+        )}
       </div>
 
-      {allowance && allowance.daysRemaining > 0 && !allowance.isOverspent && (
+      {/* Daily allowance hint */}
+      {allowance && (
         <p className="text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">
-            <FinancialAmount amount={allowance.dailyAllowance} currency={budget.currency} sign="never" />
-          </span>{' '}
-          / day for {allowance.daysRemaining} day{allowance.daysRemaining === 1 ? '' : 's'} left
-        </p>
-      )}
-      {allowance?.isOverspent && (
-        <p className="text-xs text-destructive font-medium">
-          Over by{' '}
-          <FinancialAmount amount={allowance.overspentBy} currency={budget.currency} sign="never" />
+          {allowance.isOverspent
+            ? `${formatCurrency(allowance.overspentBy, budget.currency)} over budget`
+            : allowance.daysRemaining > 0
+              ? `${formatCurrency(allowance.dailyAllowance, budget.currency)}/day · ${allowance.daysRemaining}d left`
+              : 'Last day'}
         </p>
       )}
 
-      <Dialog>
-        <DialogTrigger
-          render={
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-5 w-full rounded-2xl text-destructive hover:text-destructive"
-              disabled={isPending}
-            />
-          }
-        >
-          <Trash2 className="size-4" />
-          Delete budget
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete budget?</DialogTitle>
-            <DialogDescription>
-              &ldquo;{budget.name}&rdquo; will be permanently removed. This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
-            <Button
-              variant="destructive"
-              onClick={handleDelete}
-              disabled={isPending}
-            >
-              {isPending ? 'Deleting…' : 'Delete'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </TonalWidget>
+      {/* Actions */}
+      <div className="flex gap-2 pt-1">
+        <Link href={`/budgets/${budget.id}`}
+          className="flex-1 rounded-xl border border-primary/30 bg-primary/5 py-2 text-center text-xs font-semibold text-primary hover:bg-primary/10 transition-colors">
+          Details
+        </Link>
+        <Dialog>
+          <DialogTrigger render={
+            <Button variant="ghost" size="sm" className="rounded-xl px-3 text-muted-foreground hover:text-destructive" disabled={isPending} />
+          }>
+            <Trash2 className="size-4" />
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete budget?</DialogTitle>
+              <DialogDescription>&ldquo;{budget.name}&rdquo; will be permanently removed.</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+              <Button variant="destructive" disabled={isPending}
+                onClick={() => startTransition(async () => { await deleteBudget(budget.id) })}>
+                {isPending ? 'Deleting…' : 'Delete'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
   )
 }

--- a/src/components/dashboard/CashFlowSummary.tsx
+++ b/src/components/dashboard/CashFlowSummary.tsx
@@ -1,110 +1,64 @@
-"use client";
-
-import {
-  ArrowDownLeft,
-  ArrowUpRight,
-  Landmark,
-  WalletCards,
-} from "lucide-react";
-
-import type { Transaction } from "@/lib/db/schema";
-import {
-  AmountBox,
-  ProgressMeter,
-  StatusPill,
-  TonalWidget,
-  WidgetHeading,
-} from "@/components/shared/quiet-ledger";
+'use client'
+import { formatCurrency } from '@/lib/utils/format'
+import { cn } from '@/lib/utils'
+import type { Transaction } from '@/lib/db/schema'
 
 interface Props {
-  transactions: Transaction[];
-  currency: string;
+  transactions: Transaction[]
+  currency: string
 }
 
 export function CashFlowSummary({ transactions, currency }: Props) {
   const income = transactions
-    .filter((transaction) => transaction.type === "income")
-    .reduce(
-      (sum, transaction) =>
-        sum + Number(transaction.convertedAmount ?? transaction.amount),
-      0,
-    );
+    .filter(t => t.type === 'income')
+    .reduce((s, t) => s + Number(t.convertedAmount ?? t.amount), 0)
 
   const expense = transactions
-    .filter((transaction) => transaction.type === "expense")
-    .reduce(
-      (sum, transaction) =>
-        sum + Number(transaction.convertedAmount ?? transaction.amount),
-      0,
-    );
+    .filter(t => t.type === 'expense')
+    .reduce((s, t) => s + Number(t.convertedAmount ?? t.amount), 0)
 
-  const net = income - expense;
-  const transactionCount = transactions.length;
-  const expensePace = income > 0 ? Math.min((expense / income) * 100, 100) : 0;
-  const netTone = net > 0 ? "positive" : net < 0 ? "negative" : "neutral";
+  const net = income - expense
+  const expensePct = income > 0 ? Math.min(100, (expense / income) * 100) : 0
 
   return (
-    <TonalWidget tone="cash" className="space-y-6">
-      <WidgetHeading
-        icon={WalletCards}
-        tone="cash"
-        eyebrow="Month in motion"
-        title="Cash flow"
-        description="Money coming in, money going out, and whether this month is staying healthy."
-        action={
-          <StatusPill tone={netTone}>
-            {net > 0
-              ? "Ahead this month"
-              : net < 0
-                ? "Spending ahead"
-                : "Balanced"}
-          </StatusPill>
-        }
-      />
+    <div className="space-y-3">
+      <h2 className="text-sm font-semibold text-muted-foreground">This month</h2>
 
-      <div className="grid gap-3 sm:grid-cols-3">
-        <AmountBox
-          label="Income"
-          amount={income}
-          currency={currency}
-          icon={ArrowUpRight}
-          tone="positive"
-          count="Money received this month"
-        />
-        <AmountBox
-          label="Expenses"
-          amount={expense}
-          currency={currency}
-          icon={ArrowDownLeft}
-          tone="negative"
-          count="Spending recorded this month"
-        />
-        <AmountBox
-          label="Net"
-          amount={net}
-          currency={currency}
-          icon={Landmark}
-          tone={netTone}
-          sign="always"
-          count="Income less expenses"
-        />
-      </div>
-
-      <div className="rounded-3xl border bg-background/70 p-4 shadow-sm shadow-foreground/5">
-        <ProgressMeter
-          value={expensePace}
-          tone={expensePace > 85 ? "warning" : "positive"}
-          label="Expense pace against income"
-        />
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-          <span>{transactionCount} transactions this month</span>
-          <span>
-            {income > 0
-              ? `${Math.round(expensePace)}% of income spent`
-              : "Add income to track spending pace"}
-          </span>
+      <div className="grid grid-cols-3 gap-px rounded-2xl bg-border overflow-hidden">
+        <div className="bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Income</p>
+          <p className="text-xl font-bold tabular-nums text-emerald-600 mt-0.5">
+            {formatCurrency(income, currency)}
+          </p>
+        </div>
+        <div className="bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Expenses</p>
+          <p className="text-xl font-bold tabular-nums text-rose-600 mt-0.5">
+            {formatCurrency(expense, currency)}
+          </p>
+        </div>
+        <div className="bg-card px-4 py-3">
+          <p className="text-xs text-muted-foreground">Net</p>
+          <p className={cn('text-xl font-bold tabular-nums mt-0.5', net >= 0 ? 'text-foreground' : 'text-rose-600')}>
+            {formatCurrency(Math.abs(net), currency)}
+          </p>
         </div>
       </div>
-    </TonalWidget>
-  );
+
+      {/* Expense pace bar — flat, no card wrapper */}
+      {income > 0 && (
+        <div className="space-y-1.5">
+          <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+            <div
+              className={cn('h-full rounded-full', expensePct > 85 ? 'bg-rose-500' : 'bg-primary')}
+              style={{ width: `${expensePct}%` }}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {Math.round(expensePct)}% of income spent · {transactions.length} transactions
+          </p>
+        </div>
+      )}
+    </div>
+  )
 }

--- a/src/components/dashboard/NetworthCard.tsx
+++ b/src/components/dashboard/NetworthCard.tsx
@@ -1,121 +1,41 @@
-"use client";
-import { Landmark, PiggyBank, TrendingUp, WalletCards } from "lucide-react";
-import type { NetworthData } from "@/lib/utils/networth";
-import {
-  AmountBox,
-  FinancialAmount,
-  ProgressMeter,
-  StatusPill,
-  TonalWidget,
-  WidgetHeading,
-} from "@/components/shared/quiet-ledger";
+'use client'
+import { formatCurrency } from '@/lib/utils/format'
+import { cn } from '@/lib/utils'
+import type { NetworthData } from '@/lib/utils/networth'
 
 interface Props extends NetworthData {
-  currency: string;
+  currency: string
 }
 
-export function NetworthCard({
-  networth,
-  totalCash,
-  totalInvestments,
-  totalLiabilities,
-  currency,
-}: Props) {
-  const totalAssets = totalCash + totalInvestments;
-  const safeAssetTotal = Math.max(totalAssets, 1);
-  const cashShare = Math.max(
-    0,
-    Math.min(100, (totalCash / safeAssetTotal) * 100),
-  );
-  const investmentShare = Math.max(
-    0,
-    Math.min(100, (totalInvestments / safeAssetTotal) * 100),
-  );
-  const liabilityRatio = totalAssets > 0 ? totalLiabilities / totalAssets : 0;
-  const networthTone =
-    networth > 0 ? "positive" : networth < 0 ? "negative" : "neutral";
-
+export function NetworthCard({ networth, totalCash, totalInvestments, totalLiabilities, currency }: Props) {
   return (
-    <TonalWidget tone="primary" className="space-y-5">
-      <WidgetHeading
-        icon={PiggyBank}
-        tone="primary"
-        eyebrow="Your money home"
-        title="Net worth snapshot"
-        description="Assets minus liabilities across cash, investments, and debt."
-        action={
-          <StatusPill tone={networthTone}>
-            {networth > 0
-              ? "Positive net worth"
-              : networth < 0
-                ? "Liabilities ahead"
-                : "Getting started"}
-          </StatusPill>
-        }
-      />
-
-      <div className="rounded-[1.5rem] border bg-background/75 p-4 shadow-sm shadow-foreground/5 sm:p-5">
-        <p className="text-sm font-medium text-muted-foreground">
-          Family balance
-        </p>
-        <h2 className="financial-display mt-2 text-3xl font-extrabold text-foreground sm:text-4xl">
-          <FinancialAmount amount={networth} currency={currency} />
-        </h2>
-        <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
-          The calm headline number for the month: what you own, less what you
-          owe.
+    <div className="space-y-4">
+      {/* Big net worth number */}
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Net worth</p>
+        <p className={cn(
+          'text-5xl font-bold tabular-nums tracking-tight mt-1',
+          networth < 0 ? 'text-rose-600' : 'text-foreground'
+        )}>
+          {formatCurrency(networth, currency)}
         </p>
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-3">
-        <div className="space-y-3">
-          <AmountBox
-            label="Cash"
-            amount={totalCash}
-            currency={currency}
-            icon={WalletCards}
-            tone="cash"
-            count="Bank, wallet, cash, and savings balances"
-          />
-            <ProgressMeter
-              value={cashShare}
-              tone="cash"
-              label="Asset share"
-            />
-        </div>
-
-        <div className="space-y-3">
-          <AmountBox
-            label="Investments"
-            amount={totalInvestments}
-            currency={currency}
-            icon={TrendingUp}
-            tone="investment"
-            count="Long-term assets and market holdings"
-          />
-            <ProgressMeter
-              value={investmentShare}
-              tone="investment"
-              label="Asset share"
-            />
-        </div>
-
-        <div className="space-y-3">
-          <AmountBox
-            label="Liabilities"
-            amount={totalLiabilities}
-            currency={currency}
-            icon={Landmark}
-            tone="loan"
-            count="Loans, obligations, and debt to watch"
-          />
-            <ProgressMeter
-              value={Math.min(liabilityRatio * 100, 100)}
-              tone={liabilityRatio > 0.5 ? "negative" : "warning"}
-              label="Liability load"
-            />
-        </div>
+      {/* Three numbers flat — no cards */}
+      <div className="grid grid-cols-3 gap-px rounded-2xl bg-border overflow-hidden">
+        {[
+          { label: 'Cash', value: totalCash, color: 'text-sky-600' },
+          { label: 'Investments', value: totalInvestments, color: 'text-violet-600' },
+          { label: 'Debt', value: -totalLiabilities, color: totalLiabilities > 0 ? 'text-rose-600' : 'text-foreground' },
+        ].map(({ label, value, color }) => (
+          <div key={label} className="bg-card px-4 py-3">
+            <p className="text-xs text-muted-foreground">{label}</p>
+            <p className={cn('text-lg font-semibold tabular-nums mt-0.5', color)}>
+              {formatCurrency(Math.abs(value), currency)}
+            </p>
+          </div>
+        ))}
       </div>
-    </TonalWidget>
-  );
+    </div>
+  )
 }

--- a/src/components/dashboard/RecentTransactions.tsx
+++ b/src/components/dashboard/RecentTransactions.tsx
@@ -1,120 +1,48 @@
-"use client";
+'use client'
+import Link from 'next/link'
+import { format, parseISO } from 'date-fns'
+import { cn } from '@/lib/utils'
+import { formatCurrency } from '@/lib/utils/format'
+import { EmptyState } from '@/components/shared/quiet-ledger'
+import { ReceiptText } from 'lucide-react'
+import type { Transaction } from '@/lib/db/schema'
 
-import Link from "next/link";
-import {
-  ArrowDownLeft,
-  ArrowLeftRight,
-  ArrowUpRight,
-  ReceiptText,
-} from "lucide-react";
-
-import type { Transaction } from "@/lib/db/schema";
-import { cn } from "@/lib/utils";
-import {
-  EmptyState,
-  FinancialAmount,
-  IconBadge,
-  SectionHeader,
-  StatusPill,
-  TonalWidget,
-} from "@/components/shared/quiet-ledger";
-
-interface Props {
-  transactions: Transaction[];
-}
-
-function getTransactionIcon(type: Transaction["type"]) {
-  if (type === "income") return ArrowUpRight;
-  if (type === "expense") return ArrowDownLeft;
-  return ArrowLeftRight;
-}
-
-function getTransactionTone(type: Transaction["type"]) {
-  if (type === "income") return "positive";
-  if (type === "expense") return "negative";
-  return "info";
-}
+interface Props { transactions: Transaction[] }
 
 export function RecentTransactions({ transactions }: Props) {
   return (
-    <section className="space-y-3">
-      <SectionHeader
-        title="Recent activity"
-        description="The latest money movements added to your ledger."
-        action={
-          <Link
-            href="/transactions"
-            className="text-sm font-medium text-primary hover:underline"
-          >
-            View all
-          </Link>
-        }
-      />
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-muted-foreground">Recent</h2>
+        <Link href="/transactions" className="text-xs font-medium text-primary hover:underline">View all</Link>
+      </div>
 
       {transactions.length === 0 ? (
-        <EmptyState
-          icon={ReceiptText}
-          title="No recent transactions"
-          description="Add your first income, expense, or transfer to start building your money history."
-          className="py-8"
-        />
+        <EmptyState icon={ReceiptText} title="No transactions yet"
+          description="Add your first income or expense." className="py-8" />
       ) : (
-        <TonalWidget tone="neutral" className="space-y-2 p-3 sm:p-3">
-          {transactions.map((transaction, index) => {
-            const Icon = getTransactionIcon(transaction.type);
-            const tone = getTransactionTone(transaction.type);
-            const signedAmount =
-              transaction.type === "expense"
-                ? -Number(transaction.amount)
-                : Number(transaction.amount);
-
+        <div className="rounded-2xl border bg-card divide-y">
+          {transactions.map(t => {
+            const isIncome = t.type === 'income'
+            const isExpense = t.type === 'expense'
             return (
-              <div
-                key={transaction.id}
-                className={cn(
-                  "flex items-center justify-between gap-3 rounded-[1.5rem] border bg-background/70 p-3 shadow-sm shadow-foreground/5 transition hover:bg-background sm:p-4",
-                  index === 0 && "border-primary/20",
-                )}
-              >
-                <div className="flex min-w-0 items-center gap-3">
-                  <IconBadge
-                    icon={Icon}
-                    tone={tone}
-                    className="size-12 rounded-[1.35rem]"
-                  />
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-foreground">
-                      {transaction.note || "Untitled transaction"}
-                    </p>
-                    <div className="mt-1 flex flex-wrap items-center gap-2">
-                      <StatusPill tone={tone}>{transaction.type}</StatusPill>
-                      <span className="text-xs text-muted-foreground">
-                        {transaction.date}
-                      </span>
-                    </div>
-                  </div>
+              <div key={t.id} className="flex items-center gap-3 px-4 py-3 first:rounded-t-2xl last:rounded-b-2xl hover:bg-muted/30 transition-colors">
+                {/* Color dot */}
+                <span className={cn('size-2 shrink-0 rounded-full',
+                  isIncome ? 'bg-emerald-500' : isExpense ? 'bg-rose-500' : 'bg-sky-500')} />
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium truncate">{t.title || t.note || 'Transaction'}</p>
+                  <p className="text-xs text-muted-foreground">{format(parseISO(t.date), 'MMM d')}</p>
                 </div>
-
-                <p
-                  className={cn(
-                    "shrink-0 text-sm font-bold tabular-nums",
-                    transaction.type === "income" &&
-                      "text-emerald-700 dark:text-emerald-300",
-                    transaction.type === "expense" &&
-                      "text-rose-700 dark:text-rose-300",
-                  )}
-                >
-                  <FinancialAmount
-                    amount={signedAmount}
-                    currency={transaction.currency}
-                    sign="always"
-                  />
+                <p className={cn('text-sm font-semibold tabular-nums shrink-0',
+                  isIncome ? 'text-emerald-600' : isExpense ? 'text-rose-600' : 'text-muted-foreground')}>
+                  {isIncome ? '+' : isExpense ? '−' : ''}{formatCurrency(Number(t.amount), t.currency)}
                 </p>
               </div>
-            );
+            )
           })}
-        </TonalWidget>
+        </div>
       )}
-    </section>
-  );
+    </div>
+  )
 }

--- a/src/components/shared/Sidebar.tsx
+++ b/src/components/shared/Sidebar.tsx
@@ -80,9 +80,6 @@ export function Sidebar({ className }: { className?: string }) {
             <span className="block text-base font-bold">
               Ledgerify
             </span>
-            <span className="block text-xs text-muted-foreground">
-              Quiet Ledger
-            </span>
           </div>
         </div>
       </div>
@@ -139,15 +136,7 @@ export function Sidebar({ className }: { className?: string }) {
         </div>
       </nav>
 
-      <div className="space-y-3 border-t border-sidebar-border p-4">
-        <div className="rounded-2xl bg-background/70 p-3">
-          <p className="text-xs font-medium text-foreground">
-            Private money home
-          </p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            Built for daily clarity, family setup, and trusted use.
-          </p>
-        </div>
+      <div className="border-t border-sidebar-border p-4">
         <form action={logoutUser}>
           <button
             type="submit"

--- a/src/components/shared/quiet-ledger.tsx
+++ b/src/components/shared/quiet-ledger.tsx
@@ -151,47 +151,35 @@ export function PageShell({
 export function PageHeader({
   title,
   description,
-  eyebrow,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  eyebrow: _eyebrow,
   action,
   children,
   className,
 }: {
   title: string
   description?: string
+  /** @deprecated Eyebrows are not rendered — kept for backward compat only */
   eyebrow?: string
   action?: React.ReactNode
   children?: React.ReactNode
   className?: string
 }) {
   return (
-    <div
-      className={cn(
-        'flex flex-col gap-4 rounded-[1.75rem] border bg-card/90 p-4 shadow-sm shadow-foreground/5 backdrop-blur sm:p-5 lg:flex-row lg:items-end lg:justify-between',
-        className
-      )}
-    >
-      <div className="min-w-0 space-y-2">
-        {eyebrow && (
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-            {eyebrow}
-          </p>
+    <div className={cn('flex items-start justify-between gap-4 pb-2', className)}>
+      <div className="min-w-0">
+        <h1
+          className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+          style={{ textWrap: 'balance' } as React.CSSProperties}
+        >
+          {title}
+        </h1>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
         )}
-        <div className="space-y-1">
-          <h1
-            data-display-text
-            className="text-2xl font-extrabold text-foreground sm:text-[2rem]"
-          >
-            {title}
-          </h1>
-          {description && (
-          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-              {description}
-            </p>
-          )}
-        </div>
-        {children}
+        {children && <div className="mt-2">{children}</div>}
       </div>
-      {action && <div className="flex shrink-0 items-center gap-2">{action}</div>}
+      {action && <div className="shrink-0">{action}</div>}
     </div>
   )
 }


### PR DESCRIPTION
## What's wrong with the current UI (AI slop tells)

- `PageHeader` was a bordered card with eyebrow label + description paragraph on every page — filler nobody reads
- `DashboardSections` had a "Home sections" toggle bar — a developer feature masquerading as UI
- `TonalWidget` → `AmountBox` → `ProgressMeter` — 3 levels of nested cards everywhere
- `WidgetHeading` with icon badge + eyebrow + status pill restating what numbers already show
- `NetworthCard` had "Your money home" eyebrow, "Getting started" status pill, 3 nested AmountBox cards
- `CashFlowSummary` had "Month in motion" eyebrow, "Ahead this month" status pill
- Sidebar footer had "Private money home / Built for daily clarity, family setup, and trusted use." — filler copy

## What changed

### `PageHeader`
- Stripped to flat `<h1>` + optional action — no card border, no eyebrow rendered, no description paragraph
- `eyebrow` prop kept for backward compat (accepted, not rendered)

### Dashboard
- Killed `DashboardSections` and the visibility toggle bar entirely
- New flat layout: date/name → setup checklist → net worth → budgets → upcoming → cash flow / recent → heatmap → alerts

### `NetworthCard`
- Single `<div>`, no `TonalWidget` wrapper
- Net worth at `text-5xl` bold — the number is the UI
- Three-column breakdown (cash / investments / debt) as flat hairline-divided row, no nested cards

### `CashFlowSummary`
- Single `<div>`, no `TonalWidget`, no `WidgetHeading`
- Income / Expenses / Net as flat three-column row
- Simple progress bar below, no card wrapper

### `BudgetCard`
- Flat `rounded-2xl border` — one level deep
- Big spend number prominent
- Progress bar with Today marker pin
- Daily allowance hint in plain text

### `AccountCard`
- Color dot replaces icon badge
- Balance at `text-3xl`
- No type pill/badge

### `RecentTransactions`
- Flat `divide-y` list inside single card
- Color dot + title + amount — that's it
- No `TonalWidget`, no `IconBadge`, no `StatusPill` per row

### Sidebar
- Removed "Private money home / Built for daily clarity…" blurb
- Removed "Quiet Ledger" subtitle