### PR TITLE
feat: credit card account type, credit_payment transactions, enriched /api/v1/summary

### DIFF
--- a/docs/plans/2026-05-03-credit-card-and-summary.md
+++ b/docs/plans/2026-05-03-credit-card-and-summary.md
@@ -1,0 +1,414 @@
+# Credit Card + Summary Enrichment Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add credit card as a first-class account type, add `credit_payment` transaction type, and enrich `/api/v1/summary` with loans, insurance renewals, and investment P&L so an agent has full financial triage in one call.
+
+**Architecture:** Three independent changes — (1) schema migration adding `credit_card` account type + credit fields + `credit_payment` transaction type, (2) balance logic updated to handle credit card polarity, (3) summary route enriched with data already in existing tables.
+
+**Tech Stack:** Drizzle ORM, Postgres, Next.js 16, date-fns.
+
+---
+
+## Task 1: Schema — add `credit_card` account type + credit fields
+
+**Files:**
+- Modify: `src/lib/db/schema/accounts.ts`
+- Modify: `src/lib/db/schema/transactions.ts`
+- Run: `npm run db:generate && npm run db:migrate`
+
+**Step 1: Edit `src/lib/db/schema/accounts.ts`**
+
+Change `accountTypeEnum` to include `credit_card`:
+```ts
+export const accountTypeEnum = pgEnum('account_type', ['bank', 'wallet', 'cash', 'savings', 'credit_card'])
+```
+
+Add three new optional columns after `openingBalance`:
+```ts
+creditLimit: numeric('credit_limit', { precision: 18, scale: 4 }),
+statementDay: numeric('statement_day', { precision: 2, scale: 0 }), // day of month 1-28
+paymentDueDay: numeric('payment_due_day', { precision: 2, scale: 0 }), // day of month 1-28
+```
+
+**Step 2: Edit `src/lib/db/schema/transactions.ts`**
+
+Change `transactionTypeEnum` to include `credit_payment`:
+```ts
+export const transactionTypeEnum = pgEnum('transaction_type', ['income', 'expense', 'transfer', 'credit_payment'])
+```
+
+`credit_payment` means: money moved from a bank account TO pay off a credit card balance. It reduces the bank balance and reduces the credit card outstanding. It is NOT an expense.
+
+**Step 3: Generate + apply migration**
+```bash
+npm run db:generate
+npm run db:migrate
+```
+
+**Step 4: Verify build**
+```bash
+npm run build
+```
+Expected: clean compile, new migration file in `drizzle/`.
+
+**Step 5: Commit**
+```bash
+git add src/lib/db/schema/accounts.ts src/lib/db/schema/transactions.ts drizzle/
+git commit -m "feat(schema): credit_card account type + creditLimit/statementDay/paymentDueDay + credit_payment transaction type"
+```
+
+---
+
+## Task 2: Update `accountBalance` util + validation for credit card polarity
+
+**Files:**
+- Modify: `src/lib/utils/accountBalance.ts`
+- Modify: `src/lib/validations/transaction.ts`
+
+**Step 1: Update `getAccountBalance` in `src/lib/utils/accountBalance.ts`**
+
+For a credit card account, the balance semantics flip:
+- `openingBalance` = existing outstanding debt (positive = you owe money)
+- `expense` transactions = increase the outstanding (you spent on the card)
+- `credit_payment` transactions = decrease the outstanding (you paid the bill)
+- `income` is not valid on a credit card
+
+Replace the `txBalance` reduce with:
+```ts
+const isCreditCard = account.type === 'credit_card'
+
+const txBalance = txs.reduce((sum, t) => {
+  if (isCreditCard) {
+    // For credit cards: expenses increase debt, credit_payments reduce it
+    if (t.type === 'expense') return sum + Number(t.amount)
+    if (t.type === 'credit_payment') return sum - Number(t.amount)
+    return sum
+  } else {
+    // Normal accounts
+    if (t.type === 'income') return sum + Number(t.amount)
+    if (t.type === 'expense') return sum - Number(t.amount)
+    if (t.type === 'credit_payment') return sum - Number(t.amount) // paying from this account
+    return sum
+  }
+}, 0)
+
+return Number(account.openingBalance ?? 0) + txBalance
+```
+
+Also update `attachRunningBalance` to handle `credit_payment`:
+```ts
+export function attachRunningBalance(
+  txs: Transaction[],
+  openingBalance: number,
+  isCreditCard = false
+): Array<Transaction & { runningBalance: number }> {
+  const sorted = [...txs].sort((a, b) => a.date < b.date ? -1 : a.date > b.date ? 1 : 0)
+  let running = openingBalance
+  return sorted.map(t => {
+    if (isCreditCard) {
+      if (t.type === 'expense') running += Number(t.amount)
+      else if (t.type === 'credit_payment') running -= Number(t.amount)
+    } else {
+      if (t.type === 'income') running += Number(t.amount)
+      else if (t.type === 'expense') running -= Number(t.amount)
+      else if (t.type === 'credit_payment') running -= Number(t.amount)
+    }
+    return { ...t, runningBalance: running }
+  })
+}
+```
+
+**Step 2: Update `src/lib/validations/transaction.ts`**
+
+Add `transfer` and `credit_payment` to the type enum (currently only `income`/`expense`):
+```ts
+type: z.enum(['income', 'expense', 'transfer', 'credit_payment']),
+```
+
+Also add optional credit card fields:
+```ts
+transferToId: z.string().uuid().optional(),
+recurrenceInterval: z.coerce.number().int().positive().optional(),
+recurrenceUnit: z.enum(['day', 'week', 'month']).optional(),
+```
+
+**Step 3: Verify build**
+```bash
+npm run build
+```
+
+**Step 4: Commit**
+```bash
+git add src/lib/utils/accountBalance.ts src/lib/validations/transaction.ts
+git commit -m "feat: credit card balance polarity + credit_payment in validation"
+```
+
+---
+
+## Task 3: Update `AccountCard` + `AccountTransactionTable` to handle credit cards
+
+**Files:**
+- Modify: `src/components/accounts/AccountCard.tsx`
+- Modify: `src/components/accounts/AccountTransactionTable.tsx`
+- Modify: `src/app/(app)/accounts/[id]/page.tsx`
+
+**Step 1: Update `AccountCard`**
+
+Add `credit_card` to `TYPE_DOT` map:
+```ts
+const TYPE_DOT: Record<string, string> = {
+  bank: 'bg-sky-500',
+  wallet: 'bg-violet-500',
+  cash: 'bg-amber-500',
+  savings: 'bg-emerald-500',
+  credit_card: 'bg-rose-500',
+}
+```
+
+For credit cards, show the balance differently — outstanding debt is shown in red with "outstanding" label, and show credit limit utilisation if set:
+```tsx
+// After the balance line, add for credit cards:
+{account.type === 'credit_card' && (account as any).creditLimit && (
+  <p className="text-xs text-muted-foreground mt-1">
+    Limit: {formatCurrency(Number((account as any).creditLimit), account.currency)}
+    {' · '}{Math.round((account.balance / Number((account as any).creditLimit)) * 100)}% used
+  </p>
+)}
+```
+
+Also change the balance label for credit cards: show "outstanding" instead of just the number.
+
+**Step 2: Update `AccountTransactionTable`**
+
+Pass `isCreditCard` boolean and use `attachRunningBalance(txs, openingBalance, isCreditCard)`.
+
+**Step 3: Update `/accounts/[id]/page.tsx`**
+
+Pass `isCreditCard = account.type === 'credit_card'` to `attachRunningBalance`.
+
+**Step 4: Verify build + commit**
+```bash
+npm run build
+git add src/components/accounts/AccountCard.tsx src/components/accounts/AccountTransactionTable.tsx src/app/(app)/accounts/[id]/page.tsx
+git commit -m "feat: credit card display in AccountCard and transaction table"
+```
+
+---
+
+## Task 4: Enrich `/api/v1/summary` with loans, insurance, investments
+
+**Files:**
+- Modify: `src/app/api/v1/summary/route.ts`
+
+**Step 1: Add imports**
+
+Add to existing imports:
+```ts
+import { loans, loanPayments, insurancePolicies, investments } from '@/lib/db/schema'
+import { lte } from 'drizzle-orm'
+import { addDays, differenceInDays } from 'date-fns'
+import { getRate } from '@/lib/utils/currency'
+```
+
+**Step 2: Fetch loans, insurance, investments in parallel**
+
+Add to the existing `Promise.all`:
+```ts
+const [accountList, budgetList, recentTxs, loanList, policyList, investmentList] = await Promise.all([
+  db.select().from(accounts).where(and(eq(accounts.userId, userId), isNull(accounts.deletedAt))),
+  db.select().from(budgets).where(and(eq(budgets.userId, userId), isNull(budgets.deletedAt))),
+  db.select().from(transactions).where(and(
+    eq(transactions.userId, userId),
+    isNull(transactions.deletedAt),
+    gte(transactions.date, heatmapStart),
+  )),
+  db.select().from(loans).where(and(eq(loans.userId, userId), isNull(loans.deletedAt))),
+  db.select().from(insurancePolicies).where(and(eq(insurancePolicies.userId, userId), isNull(insurancePolicies.deletedAt))),
+  db.select().from(investments).where(and(eq(investments.userId, userId), isNull(investments.deletedAt))),
+])
+```
+
+**Step 3: Build `upcomingObligations` array**
+
+After the existing budget summary, add:
+```ts
+const today = new Date()
+const in30Days = format(addDays(today, 30), 'yyyy-MM-dd')
+const todayStr = format(today, 'yyyy-MM-dd')
+
+// Loan EMIs due in next 30 days
+const upcomingEmis = loanList
+  .filter(l => Number(l.outstandingBalance ?? 0) > 0)
+  .map(l => {
+    // Next EMI is on same day-of-month as startDate, next occurrence from today
+    const startDate = new Date(l.startDate)
+    const emiDay = startDate.getDate()
+    const nextEmi = new Date(today.getFullYear(), today.getMonth(), emiDay)
+    if (nextEmi < today) nextEmi.setMonth(nextEmi.getMonth() + 1)
+    const nextEmiStr = format(nextEmi, 'yyyy-MM-dd')
+    if (nextEmiStr > in30Days) return null
+    return {
+      type: 'loan_emi' as const,
+      id: l.id,
+      name: l.name,
+      amount: Number(l.emiAmount),
+      currency: l.currency,
+      dueDate: nextEmiStr,
+      daysUntil: differenceInDays(nextEmi, today),
+      outstandingBalance: Number(l.outstandingBalance ?? 0),
+    }
+  })
+  .filter(Boolean)
+
+// Insurance renewals due in next 30 days
+const upcomingRenewals = policyList
+  .filter(p => p.renewalDate && p.renewalDate >= todayStr && p.renewalDate <= in30Days)
+  .map(p => ({
+    type: 'insurance_renewal' as const,
+    id: p.id,
+    name: p.name,
+    amount: Number(p.premiumAmount),
+    currency: p.currency,
+    dueDate: p.renewalDate!,
+    daysUntil: differenceInDays(new Date(p.renewalDate!), today),
+    provider: p.provider,
+  }))
+
+// FD/bond maturities in next 30 days
+const upcomingMaturities = investmentList
+  .filter(i => i.maturityDate && i.maturityDate >= todayStr && i.maturityDate <= in30Days)
+  .map(i => ({
+    type: 'investment_maturity' as const,
+    id: i.id,
+    name: i.name,
+    assetType: i.assetType,
+    currency: i.currency,
+    dueDate: i.maturityDate!,
+    daysUntil: differenceInDays(new Date(i.maturityDate!), today),
+    estimatedValue: Number(i.currentPrice ?? i.buyPrice ?? 0) * Number(i.quantity ?? 1),
+  }))
+
+const upcomingObligations = [
+  ...upcomingEmis,
+  ...upcomingRenewals,
+  ...upcomingMaturities,
+].sort((a, b) => (a!.daysUntil) - (b!.daysUntil))
+```
+
+**Step 4: Build `investmentSummary`**
+
+```ts
+const investmentSummary = await Promise.all(investmentList.map(async inv => {
+  const rate = await getRate(inv.currency, baseCurrency)
+  const currentValue = Number(inv.currentPrice ?? inv.buyPrice ?? 0) * Number(inv.quantity ?? 1) * rate
+  const costBasis = Number(inv.buyPrice ?? 0) * Number(inv.quantity ?? 1) * rate
+  const unrealisedPnl = currentValue - costBasis
+  const unrealisedPnlPct = costBasis > 0 ? (unrealisedPnl / costBasis) * 100 : 0
+  return {
+    id: inv.id,
+    name: inv.name,
+    assetType: inv.assetType,
+    currency: inv.currency,
+    currentValue: Math.round(currentValue),
+    costBasis: Math.round(costBasis),
+    unrealisedPnl: Math.round(unrealisedPnl),
+    unrealisedPnlPct: Math.round(unrealisedPnlPct * 10) / 10,
+    maturityDate: inv.maturityDate,
+  }
+}))
+```
+
+**Step 5: Add `creditCards` section**
+
+```ts
+// Credit card outstanding summary
+const creditCardSummary = accountSummary
+  .filter(a => a.type === 'credit_card')
+  .map(a => ({
+    id: a.id,
+    name: a.name,
+    outstanding: a.balance, // positive = you owe this much
+    currency: a.currency,
+  }))
+```
+
+**Step 6: Return enriched response**
+
+Update the `return NextResponse.json(...)` to include:
+```ts
+return NextResponse.json({
+  generatedAt: new Date().toISOString(),
+  baseCurrency,
+  networth,
+  accounts: accountSummary,
+  creditCards: creditCardSummary,
+  budgets: budgetSummary,
+  upcomingObligations,   // ← NEW: EMIs, renewals, maturities in next 30 days
+  investments: investmentSummary,  // ← NEW: P&L per investment
+  anomalies,
+  meta: {
+    dailyAvgSpend30d: Math.round(dailyAvg),
+    totalSpent30d: Math.round(totalSpent30),
+    totalCreditOutstanding: creditCardSummary.reduce((s, c) => s + c.outstanding, 0),
+    totalUpcomingObligations30d: upcomingObligations.reduce((s, o) => s + (o?.amount ?? 0), 0),
+  },
+})
+```
+
+**Step 7: Verify build**
+```bash
+npm run build
+```
+
+**Step 8: Commit**
+```bash
+git add src/app/api/v1/summary/route.ts
+git commit -m "feat(api): enrich /api/v1/summary with loans, insurance renewals, investment P&L, credit cards"
+```
+
+---
+
+## Task 5: Update Settings > Accounts form to support credit card fields
+
+**Files:**
+- Modify: `src/components/settings/AccountsClient.tsx`
+
+**Step 1: Read the file** — find the account creation form.
+
+**Step 2: Add `credit_card` as a selectable type option**
+
+In whatever select/enum the form uses for account type, add `credit_card` as an option with label "Credit Card".
+
+**Step 3: Show credit card fields conditionally**
+
+When `type === 'credit_card'` is selected, show three additional fields:
+- **Credit Limit** (number input, optional)
+- **Statement Day** (number 1–28, "Day of month your statement is generated")
+- **Payment Due Day** (number 1–28, "Day of month your payment is due")
+
+**Step 4: Update the server action** (`src/app/actions/settings.ts` or wherever account creation is handled) to accept and save `creditLimit`, `statementDay`, `paymentDueDay`.
+
+**Step 5: Verify build + commit**
+```bash
+npm run build
+git add src/components/settings/AccountsClient.tsx src/app/actions/settings.ts
+git commit -m "feat: credit card fields in account settings form"
+```
+
+---
+
+## Task 6: Final build + push PR
+
+**Step 1: Full build**
+```bash
+npm run build
+```
+
+**Step 2: Push**
+```bash
+git push origin feat/credit-card-and-summary
+```
+
+**Step 3: PR**
+Title: `feat: credit card account type, credit_payment transactions, enriched /api/v1/summary`

--- a/drizzle/0002_lush_frightful_four.sql
+++ b/drizzle/0002_lush_frightful_four.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "public"."account_type" ADD VALUE 'credit_card';--> statement-breakpoint
+ALTER TYPE "public"."transaction_type" ADD VALUE 'credit_payment';--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "credit_limit" numeric(18, 4);--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "statement_day" numeric(2, 0);--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "payment_due_day" numeric(2, 0);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1783 @@
+{
+  "id": "ff51a912-6ec0-4f7a-ac6d-7a43249a8fe5",
+  "prevId": "132bc69e-f786-4cb2-a272-47a702c5bbf3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Asia/Kolkata'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "credit_limit": {
+          "name": "credit_limit",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_day": {
+          "name": "statement_day",
+          "type": "numeric(2, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_due_day": {
+          "name": "payment_due_day",
+          "type": "numeric(2, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "category_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_user_id_users_id_fk": {
+          "name": "categories_user_id_users_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_tags": {
+      "name": "transaction_tags",
+      "schema": "",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_tags_transaction_id_transactions_id_fk": {
+          "name": "transaction_tags_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transaction_tags_tag_id_tags_id_fk": {
+          "name": "transaction_tags_tag_id_tags_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transaction_tags_transaction_id_tag_id_pk": {
+          "name": "transaction_tags_transaction_id_tag_id_pk",
+          "columns": [
+            "transaction_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "converted_amount": {
+          "name": "converted_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_currency": {
+          "name": "base_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "numeric(5, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_recurring_id": {
+          "name": "parent_recurring_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_to_id": {
+          "name": "transfer_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_category_id_categories_id_fk": {
+          "name": "transactions_category_id_categories_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_transfer_to_id_accounts_id_fk": {
+          "name": "transactions_transfer_to_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "transfer_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_transactions": {
+      "name": "investment_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investment_id": {
+          "name": "investment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "investment_tx_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "investment_transactions_investment_id_investments_id_fk": {
+          "name": "investment_transactions_investment_id_investments_id_fk",
+          "tableFrom": "investment_transactions",
+          "tableTo": "investments",
+          "columnsFrom": [
+            "investment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "asset_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buy_price": {
+          "name": "buy_price",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_price": {
+          "name": "current_price",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_price_updated_at": {
+          "name": "current_price_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maturity_date": {
+          "name": "maturity_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "investments_user_id_users_id_fk": {
+          "name": "investments_user_id_users_id_fk",
+          "tableFrom": "investments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_payments": {
+      "name": "loan_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "loan_id": {
+          "name": "loan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_component": {
+          "name": "principal_component",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interest_component": {
+          "name": "interest_component",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "loan_payments_loan_id_loans_id_fk": {
+          "name": "loan_payments_loan_id_loans_id_fk",
+          "tableFrom": "loan_payments",
+          "tableTo": "loans",
+          "columnsFrom": [
+            "loan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loans": {
+      "name": "loans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loan_type": {
+          "name": "loan_type",
+          "type": "loan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_rate": {
+          "name": "interest_rate",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenure_months": {
+          "name": "tenure_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emi_amount": {
+          "name": "emi_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outstanding_balance": {
+          "name": "outstanding_balance",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "loans_user_id_users_id_fk": {
+          "name": "loans_user_id_users_id_fk",
+          "tableFrom": "loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_payments": {
+      "name": "insurance_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "insurance_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "insurance_payments_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_payments_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_payments",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_type": {
+          "name": "policy_type",
+          "type": "policy_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premium_amount": {
+          "name": "premium_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premium_frequency": {
+          "name": "premium_frequency",
+          "type": "premium_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverage_amount": {
+          "name": "coverage_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "renewal_date": {
+          "name": "renewal_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nominee": {
+          "name": "nominee",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "insurance_policies_user_id_users_id_fk": {
+          "name": "insurance_policies_user_id_users_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "period_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_anchor_date": {
+          "name": "period_anchor_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budgets_category_id_categories_id_fk": {
+          "name": "budgets_category_id_categories_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savings_goals": {
+      "name": "savings_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_amount": {
+          "name": "target_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "linked_account_id": {
+          "name": "linked_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "goal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "savings_goals_user_id_users_id_fk": {
+          "name": "savings_goals_user_id_users_id_fk",
+          "tableFrom": "savings_goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "savings_goals_linked_account_id_accounts_id_fk": {
+          "name": "savings_goals_linked_account_id_accounts_id_fk",
+          "tableFrom": "savings_goals",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "linked_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_rates": {
+      "name": "exchange_rates",
+      "schema": "",
+      "columns": {
+        "base": {
+          "name": "base",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "numeric(18, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "exchange_rates_base_target_pk": {
+          "name": "exchange_rates_base_target_pk",
+          "columns": [
+            "base",
+            "target"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_keywords": {
+      "name": "category_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_keywords_user_id_users_id_fk": {
+          "name": "category_keywords_user_id_users_id_fk",
+          "tableFrom": "category_keywords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_keywords_category_id_categories_id_fk": {
+          "name": "category_keywords_category_id_categories_id_fk",
+          "tableFrom": "category_keywords",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "bank",
+        "wallet",
+        "cash",
+        "savings",
+        "credit_card"
+      ]
+    },
+    "public.category_type": {
+      "name": "category_type",
+      "schema": "public",
+      "values": [
+        "income",
+        "expense"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "income",
+        "expense",
+        "transfer",
+        "credit_payment"
+      ]
+    },
+    "public.asset_type": {
+      "name": "asset_type",
+      "schema": "public",
+      "values": [
+        "stock",
+        "mf",
+        "crypto",
+        "fd",
+        "ppf",
+        "nps",
+        "gold",
+        "silver",
+        "real_estate",
+        "savings",
+        "other"
+      ]
+    },
+    "public.investment_tx_type": {
+      "name": "investment_tx_type",
+      "schema": "public",
+      "values": [
+        "buy",
+        "sell",
+        "dividend",
+        "interest",
+        "bonus"
+      ]
+    },
+    "public.loan_type": {
+      "name": "loan_type",
+      "schema": "public",
+      "values": [
+        "home",
+        "personal",
+        "vehicle",
+        "education",
+        "other"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "paid",
+        "missed",
+        "partial"
+      ]
+    },
+    "public.insurance_payment_status": {
+      "name": "insurance_payment_status",
+      "schema": "public",
+      "values": [
+        "paid",
+        "due",
+        "missed"
+      ]
+    },
+    "public.policy_type": {
+      "name": "policy_type",
+      "schema": "public",
+      "values": [
+        "life",
+        "health",
+        "vehicle",
+        "property",
+        "term",
+        "other"
+      ]
+    },
+    "public.premium_frequency": {
+      "name": "premium_frequency",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "quarterly",
+        "annual"
+      ]
+    },
+    "public.goal_status": {
+      "name": "goal_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "achieved",
+        "abandoned"
+      ]
+    },
+    "public.period_type": {
+      "name": "period_type",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "weekly"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777806986503,
       "tag": "0001_soft_anita_blake",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777820252508,
+      "tag": "0002_lush_frightful_four",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/accounts/[id]/page.tsx
+++ b/src/app/(app)/accounts/[id]/page.tsx
@@ -37,7 +37,11 @@ export default async function AccountDetailPage({
       )),
   ])
 
-  const withBalance = attachRunningBalance(txList, Number(account.openingBalance ?? 0))
+  const withBalance = attachRunningBalance(
+    txList,
+    Number(account.openingBalance ?? 0),
+    account.type === 'credit_card'
+  )
   const currentBalance = withBalance.length > 0
     ? withBalance[withBalance.length - 1].runningBalance
     : Number(account.openingBalance ?? 0)
@@ -50,7 +54,10 @@ export default async function AccountDetailPage({
       <PageHeader
         eyebrow={account.type}
         title={account.name}
-        description={`Live balance: ${formatCurrency(currentBalance, account.currency)} · ${txList.length} transactions`}
+        description={account.type === 'credit_card'
+          ? `Outstanding: ${formatCurrency(currentBalance, account.currency)} · ${txList.length} transactions`
+          : `Live balance: ${formatCurrency(currentBalance, account.currency)} · ${txList.length} transactions`
+        }
       />
       <AccountTransactionTable
         transactions={displayTxs}

--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -48,7 +48,7 @@ export async function createAccount(_: unknown, formData: FormData) {
 
   const schema = z.object({
     name: z.string().min(1),
-    type: z.enum(['bank', 'wallet', 'cash', 'savings']),
+    type: z.enum(['bank', 'wallet', 'cash', 'savings', 'credit_card']),
     currency: z.string().length(3),
   })
   const raw = Object.fromEntries(formData)
@@ -58,7 +58,17 @@ export async function createAccount(_: unknown, formData: FormData) {
   })
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  await db.insert(accounts).values({ ...parsed.data, userId: session.user.id })
+  const creditLimit = formData.get('creditLimit') ? String(formData.get('creditLimit')) : null
+  const statementDay = formData.get('statementDay') ? String(formData.get('statementDay')) : null
+  const paymentDueDay = formData.get('paymentDueDay') ? String(formData.get('paymentDueDay')) : null
+
+  await db.insert(accounts).values({
+    ...parsed.data,
+    userId: session.user.id,
+    creditLimit,
+    statementDay,
+    paymentDueDay,
+  })
   revalidatePath('/settings/accounts')
   revalidatePath('/dashboard')
   revalidatePath('/transactions')

--- a/src/app/actions/transactions.ts
+++ b/src/app/actions/transactions.ts
@@ -81,6 +81,7 @@ export async function createTransaction(_: unknown, formData: FormData) {
       convertedAmount: String(data.amount * rate),
       baseCurrency,
       isRecurring: data.isRecurring ?? false,
+      recurrenceInterval: data.recurrenceInterval != null ? String(data.recurrenceInterval) : undefined,
     })
     .returning();
 
@@ -150,6 +151,7 @@ export async function updateTransaction(_: unknown, formData: FormData) {
       convertedAmount: String(data.amount * rate),
       baseCurrency,
       updatedAt: new Date(),
+      recurrenceInterval: data.recurrenceInterval != null ? String(data.recurrenceInterval) : undefined,
     })
     .where(
       and(eq(transactions.id, id), eq(transactions.userId, session.user.id)),

--- a/src/app/api/v1/summary/route.ts
+++ b/src/app/api/v1/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
-import { transactions, accounts, budgets, users, loans, insurancePolicies, investments } from '@/lib/db/schema'
+import { transactions, accounts, budgets, loans, insurancePolicies, investments } from '@/lib/db/schema'
 import { eq, and, isNull, gte } from 'drizzle-orm'
 import { getBudgetPeriod, getDailyAllowance } from '@/lib/utils/budgetPeriod'
 import { getAccountBalance } from '@/lib/utils/accountBalance'

--- a/src/app/api/v1/summary/route.ts
+++ b/src/app/api/v1/summary/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { resolveSession } from '@/lib/api/auth'
 import { db } from '@/lib/db'
-import { transactions, accounts, budgets, users } from '@/lib/db/schema'
+import { transactions, accounts, budgets, users, loans, insurancePolicies, investments } from '@/lib/db/schema'
 import { eq, and, isNull, gte } from 'drizzle-orm'
 import { getBudgetPeriod, getDailyAllowance } from '@/lib/utils/budgetPeriod'
 import { getAccountBalance } from '@/lib/utils/accountBalance'
 import { computeNetworth } from '@/lib/utils/networth'
-import { format, subDays } from 'date-fns'
+import { format, subDays, addDays, differenceInDays } from 'date-fns'
+import { getRate } from '@/lib/utils/currency'
 
 export async function GET(req: NextRequest) {
   const auth = await resolveSession(req)
@@ -20,7 +21,7 @@ export async function GET(req: NextRequest) {
 
   const heatmapStart = format(subDays(new Date(), 30), 'yyyy-MM-dd')
 
-  const [accountList, budgetList, recentTxs] = await Promise.all([
+  const [accountList, budgetList, recentTxs, loanList, policyList, investmentList] = await Promise.all([
     db.select().from(accounts).where(and(eq(accounts.userId, userId), isNull(accounts.deletedAt))),
     db.select().from(budgets).where(and(eq(budgets.userId, userId), isNull(budgets.deletedAt))),
     db.select().from(transactions).where(and(
@@ -28,6 +29,9 @@ export async function GET(req: NextRequest) {
       isNull(transactions.deletedAt),
       gte(transactions.date, heatmapStart),
     )),
+    db.select().from(loans).where(and(eq(loans.userId, userId), isNull(loans.deletedAt))),
+    db.select().from(insurancePolicies).where(and(eq(insurancePolicies.userId, userId), isNull(insurancePolicies.deletedAt))),
+    db.select().from(investments).where(and(eq(investments.userId, userId), isNull(investments.deletedAt))),
   ])
 
   // Account balances
@@ -72,6 +76,97 @@ export async function GET(req: NextRequest) {
   // Networth
   const networth = await computeNetworth(userId, baseCurrency)
 
+  const today = new Date()
+  const in30Days = format(addDays(today, 30), 'yyyy-MM-dd')
+  const todayStr = format(today, 'yyyy-MM-dd')
+
+  // Loan EMIs due within 30 days
+  const upcomingEmis = loanList
+    .filter(l => Number(l.outstandingBalance ?? 0) > 0)
+    .map(l => {
+      const emiDay = new Date(l.startDate).getDate()
+      const candidate = new Date(today.getFullYear(), today.getMonth(), emiDay)
+      if (candidate < today) candidate.setMonth(candidate.getMonth() + 1)
+      const dueDateStr = format(candidate, 'yyyy-MM-dd')
+      if (dueDateStr > in30Days) return null
+      return {
+        type: 'loan_emi' as const,
+        id: l.id,
+        name: l.name,
+        amount: Number(l.emiAmount),
+        currency: l.currency,
+        dueDate: dueDateStr,
+        daysUntil: differenceInDays(candidate, today),
+        outstandingBalance: Number(l.outstandingBalance ?? 0),
+      }
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+
+  // Insurance renewals due within 30 days
+  const upcomingRenewals = policyList
+    .filter(p => p.renewalDate && p.renewalDate >= todayStr && p.renewalDate <= in30Days)
+    .map(p => ({
+      type: 'insurance_renewal' as const,
+      id: p.id,
+      name: p.name,
+      amount: Number(p.premiumAmount),
+      currency: p.currency,
+      dueDate: p.renewalDate!,
+      daysUntil: differenceInDays(new Date(p.renewalDate!), today),
+      provider: p.provider ?? null,
+    }))
+
+  // Investment maturities in 30 days (FD, bonds, NPS, PPF)
+  const upcomingMaturities = investmentList
+    .filter(i => i.maturityDate && i.maturityDate >= todayStr && i.maturityDate <= in30Days)
+    .map(i => ({
+      type: 'investment_maturity' as const,
+      id: i.id,
+      name: i.name,
+      assetType: i.assetType,
+      currency: i.currency,
+      dueDate: i.maturityDate!,
+      daysUntil: differenceInDays(new Date(i.maturityDate!), today),
+      estimatedValue: Math.round(Number(i.currentPrice ?? i.buyPrice ?? 0) * Number(i.quantity ?? 1)),
+    }))
+
+  const upcomingObligations = [
+    ...upcomingEmis,
+    ...upcomingRenewals,
+    ...upcomingMaturities,
+  ].sort((a, b) => a.daysUntil - b.daysUntil)
+
+  // Investment P&L
+  const investmentSummary = await Promise.all(investmentList.map(async inv => {
+    const rate = await getRate(inv.currency, baseCurrency)
+    const qty = Number(inv.quantity ?? 1)
+    const currentValue = Number(inv.currentPrice ?? inv.buyPrice ?? 0) * qty * rate
+    const costBasis = Number(inv.buyPrice ?? 0) * qty * rate
+    const unrealisedPnl = currentValue - costBasis
+    const unrealisedPnlPct = costBasis > 0 ? (unrealisedPnl / costBasis) * 100 : 0
+    return {
+      id: inv.id,
+      name: inv.name,
+      assetType: inv.assetType,
+      currency: inv.currency,
+      currentValue: Math.round(currentValue),
+      costBasis: Math.round(costBasis),
+      unrealisedPnl: Math.round(unrealisedPnl),
+      unrealisedPnlPct: Math.round(unrealisedPnlPct * 10) / 10,
+      maturityDate: inv.maturityDate ?? null,
+    }
+  }))
+
+  // Credit card outstanding summary
+  const creditCardSummary = accountSummary
+    .filter(a => a.type === 'credit_card')
+    .map(a => ({
+      id: a.id,
+      name: a.name,
+      outstanding: a.balance,
+      currency: a.currency,
+    }))
+
   // Anomalies: expense transactions > 2x 30-day daily average
   const expenseTxs = recentTxs.filter(t => t.type === 'expense')
   const totalSpent30 = expenseTxs.reduce((s, t) => s + Number(t.amount), 0)
@@ -94,11 +189,18 @@ export async function GET(req: NextRequest) {
     baseCurrency,
     networth,
     accounts: accountSummary,
+    creditCards: creditCardSummary,
     budgets: budgetSummary,
+    upcomingObligations,
+    investments: investmentSummary,
     anomalies,
     meta: {
       dailyAvgSpend30d: Math.round(dailyAvg),
       totalSpent30d: Math.round(totalSpent30),
+      totalCreditOutstanding: creditCardSummary.reduce((s, c) => s + c.outstanding, 0),
+      totalUpcomingObligations30d: upcomingObligations.reduce((s, o) => s + ('amount' in o ? o.amount : 0), 0),
+      totalInvestmentValue: investmentSummary.reduce((s, i) => s + i.currentValue, 0),
+      totalUnrealisedPnl: investmentSummary.reduce((s, i) => s + i.unrealisedPnl, 0),
     },
   })
 }

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -12,9 +12,16 @@ const TYPE_DOT: Record<string, string> = {
   wallet: 'bg-violet-500',
   cash: 'bg-amber-500',
   savings: 'bg-emerald-500',
+  credit_card: 'bg-rose-500',
 }
 
 export function AccountCard({ account }: Props) {
+  const isCreditCard = account.type === 'credit_card'
+  const creditLimit = (account as any).creditLimit ? Number((account as any).creditLimit) : null
+  const utilisationPct = creditLimit && creditLimit > 0
+    ? Math.round((account.balance / creditLimit) * 100)
+    : null
+
   return (
     <Link href={`/accounts/${account.id}`}
       className="group block rounded-2xl border bg-card p-5 hover:shadow-md transition-shadow">
@@ -25,10 +32,26 @@ export function AccountCard({ account }: Props) {
       <p className="text-sm font-semibold truncate">{account.name}</p>
       <p className={cn(
         'text-3xl font-bold tabular-nums tracking-tight mt-1',
-        account.balance < 0 ? 'text-rose-600' : 'text-foreground'
+        isCreditCard ? 'text-rose-600' : account.balance < 0 ? 'text-rose-600' : 'text-foreground'
       )}>
         {formatCurrency(account.balance, account.currency)}
       </p>
+      <p className="text-xs text-muted-foreground mt-0.5">
+        {isCreditCard ? 'outstanding' : account.currency}
+      </p>
+      {isCreditCard && creditLimit && (
+        <div className="mt-2 space-y-1">
+          <div className="h-1 w-full rounded-full bg-muted overflow-hidden">
+            <div
+              className={cn('h-full rounded-full', utilisationPct! > 80 ? 'bg-rose-500' : utilisationPct! > 50 ? 'bg-amber-400' : 'bg-primary')}
+              style={{ width: `${Math.min(100, utilisationPct!)}%` }}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {utilisationPct}% of {formatCurrency(creditLimit, account.currency)} limit
+          </p>
+        </div>
+      )}
     </Link>
   )
 }

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -17,7 +17,7 @@ const TYPE_DOT: Record<string, string> = {
 
 export function AccountCard({ account }: Props) {
   const isCreditCard = account.type === 'credit_card'
-  const creditLimit = (account as any).creditLimit ? Number((account as any).creditLimit) : null
+  const creditLimit = account.creditLimit ? Number(account.creditLimit) : null
   const utilisationPct = creditLimit && creditLimit > 0
     ? Math.round((account.balance / creditLimit) * 100)
     : null

--- a/src/components/settings/AccountsClient.tsx
+++ b/src/components/settings/AccountsClient.tsx
@@ -41,6 +41,7 @@ const accountMeta = {
   wallet: { label: 'Wallet', icon: Wallet, tone: 'primary' },
   cash: { label: 'Cash', icon: Banknote, tone: 'positive' },
   savings: { label: 'Savings', icon: WalletCards, tone: 'warning' },
+  credit_card: { label: 'Credit Card', icon: WalletCards, tone: 'warning' },
 } as const
 
 function AddAccountForm({ defaultCurrency = 'INR' }: { defaultCurrency?: string }) {

--- a/src/components/settings/AccountsClient.tsx
+++ b/src/components/settings/AccountsClient.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useTransition, useActionState } from 'react'
+import { useTransition, useActionState, useState } from 'react'
 import { createAccount, deleteAccount } from '@/app/actions/settings'
 import {
   EmptyState,
@@ -46,6 +46,7 @@ const accountMeta = {
 
 function AddAccountForm({ defaultCurrency = 'INR' }: { defaultCurrency?: string }) {
   const [state, action, pending] = useActionState(createAccount, null)
+  const [selectedType, setSelectedType] = useState('bank')
 
   return (
     <form action={action} className="mt-5 space-y-5 px-4">
@@ -60,12 +61,14 @@ function AddAccountForm({ defaultCurrency = 'INR' }: { defaultCurrency?: string 
             id="acc-type"
             name="type"
             className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-            defaultValue="bank"
+            value={selectedType}
+            onChange={(e) => setSelectedType(e.target.value)}
           >
             <option value="bank">Bank</option>
             <option value="wallet">Wallet</option>
             <option value="cash">Cash</option>
             <option value="savings">Savings</option>
+            <option value="credit_card">Credit Card</option>
           </select>
         </div>
         <div className="space-y-1">
@@ -80,6 +83,46 @@ function AddAccountForm({ defaultCurrency = 'INR' }: { defaultCurrency?: string 
           />
         </div>
       </div>
+
+      {selectedType === 'credit_card' && (
+        <div className="space-y-4 rounded-lg border border-border p-4">
+          <div className="space-y-1">
+            <Label htmlFor="acc-credit-limit">Credit limit</Label>
+            <Input
+              id="acc-credit-limit"
+              name="creditLimit"
+              type="number"
+              placeholder="e.g. 100000"
+              min={0}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1">
+              <Label htmlFor="acc-statement-day">Statement date (day of month)</Label>
+              <Input
+                id="acc-statement-day"
+                name="statementDay"
+                type="number"
+                placeholder="e.g. 5"
+                min={1}
+                max={28}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="acc-payment-due-day">Payment due (day of month)</Label>
+              <Input
+                id="acc-payment-due-day"
+                name="paymentDueDay"
+                type="number"
+                placeholder="e.g. 25"
+                min={1}
+                max={28}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       {state && 'error' in state && state.error && (
         <p className="text-sm text-destructive">{state.error}</p>
       )}

--- a/src/components/shared/quiet-ledger.tsx
+++ b/src/components/shared/quiet-ledger.tsx
@@ -151,7 +151,6 @@ export function PageShell({
 export function PageHeader({
   title,
   description,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   eyebrow: _eyebrow,
   action,
   children,

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth/config'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function resolveSession(
-  req: NextRequest,
+  _req: NextRequest,
 ): Promise<{ userId: string } | NextResponse> {
   const session = await auth()
   if (!session?.user?.id) {

--- a/src/lib/db/schema/accounts.ts
+++ b/src/lib/db/schema/accounts.ts
@@ -1,7 +1,7 @@
 import { pgTable, uuid, varchar, numeric, timestamp, pgEnum } from 'drizzle-orm/pg-core'
 import { users } from './users'
 
-export const accountTypeEnum = pgEnum('account_type', ['bank', 'wallet', 'cash', 'savings'])
+export const accountTypeEnum = pgEnum('account_type', ['bank', 'wallet', 'cash', 'savings', 'credit_card'])
 
 export const accounts = pgTable('accounts', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -10,6 +10,9 @@ export const accounts = pgTable('accounts', {
   type: accountTypeEnum('type').notNull(),
   currency: varchar('currency', { length: 3 }).notNull(),
   openingBalance: numeric('opening_balance', { precision: 18, scale: 4 }).notNull().default('0'),
+  creditLimit: numeric('credit_limit', { precision: 18, scale: 4 }),
+  statementDay: numeric('statement_day', { precision: 2, scale: 0 }),
+  paymentDueDay: numeric('payment_due_day', { precision: 2, scale: 0 }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   deletedAt: timestamp('deleted_at', { withTimezone: true }),

--- a/src/lib/db/schema/transactions.ts
+++ b/src/lib/db/schema/transactions.ts
@@ -4,7 +4,7 @@ import { accounts } from './accounts'
 import { categories } from './categories'
 import { tags } from './tags'
 
-export const transactionTypeEnum = pgEnum('transaction_type', ['income', 'expense', 'transfer'])
+export const transactionTypeEnum = pgEnum('transaction_type', ['income', 'expense', 'transfer', 'credit_payment'])
 
 export const transactions = pgTable('transactions', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/src/lib/utils/accountBalance.ts
+++ b/src/lib/utils/accountBalance.ts
@@ -3,50 +3,50 @@ import { transactions, accounts } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import type { Transaction } from '@/lib/db/schema'
 
-/**
- * Returns live balance for an account:
- * openingBalance + SUM(income) - SUM(expense)
- * Transfers are excluded from balance calculation.
- */
 export async function getAccountBalance(accountId: string, userId: string): Promise<number> {
   const [account] = await db.select().from(accounts)
     .where(and(eq(accounts.id, accountId), eq(accounts.userId, userId), isNull(accounts.deletedAt)))
-
   if (!account) return 0
 
   const txs = await db.select().from(transactions)
-    .where(and(
-      eq(transactions.accountId, accountId),
-      eq(transactions.userId, userId),
-      isNull(transactions.deletedAt),
-    ))
+    .where(and(eq(transactions.accountId, accountId), eq(transactions.userId, userId), isNull(transactions.deletedAt)))
+
+  const isCreditCard = account.type === 'credit_card'
 
   const txBalance = txs.reduce((sum, t) => {
-    if (t.type === 'income') return sum + Number(t.amount)
-    if (t.type === 'expense') return sum - Number(t.amount)
-    return sum
+    if (isCreditCard) {
+      // Credit card: expenses increase outstanding debt, credit_payments reduce it
+      if (t.type === 'expense') return sum + Number(t.amount)
+      if (t.type === 'credit_payment') return sum - Number(t.amount)
+      return sum
+    } else {
+      // Normal accounts: income adds, expense/credit_payment deduct
+      if (t.type === 'income') return sum + Number(t.amount)
+      if (t.type === 'expense') return sum - Number(t.amount)
+      if (t.type === 'credit_payment') return sum - Number(t.amount)
+      return sum
+    }
   }, 0)
 
   return Number(account.openingBalance ?? 0) + txBalance
 }
 
-/**
- * Returns transactions sorted ASC by date with a running balance column attached.
- * openingBalance is the account's opening balance.
- */
 export function attachRunningBalance(
   txs: Transaction[],
-  openingBalance: number
+  openingBalance: number,
+  isCreditCard = false
 ): Array<Transaction & { runningBalance: number }> {
-  const sorted = [...txs].sort((a, b) => {
-    if (a.date < b.date) return -1
-    if (a.date > b.date) return 1
-    return 0
-  })
+  const sorted = [...txs].sort((a, b) => a.date < b.date ? -1 : a.date > b.date ? 1 : 0)
   let running = openingBalance
   return sorted.map(t => {
-    if (t.type === 'income') running += Number(t.amount)
-    else if (t.type === 'expense') running -= Number(t.amount)
+    if (isCreditCard) {
+      if (t.type === 'expense') running += Number(t.amount)
+      else if (t.type === 'credit_payment') running -= Number(t.amount)
+    } else {
+      if (t.type === 'income') running += Number(t.amount)
+      else if (t.type === 'expense') running -= Number(t.amount)
+      else if (t.type === 'credit_payment') running -= Number(t.amount)
+    }
     return { ...t, runningBalance: running }
   })
 }

--- a/src/lib/validations/transaction.ts
+++ b/src/lib/validations/transaction.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const transactionSchema = z.object({
   accountId: z.string().uuid(),
-  type: z.enum(['income', 'expense']),
+  type: z.enum(['income', 'expense', 'transfer', 'credit_payment']),
   amount: z.coerce.number().positive(),
   currency: z.string().length(3),
   categoryId: z.string().uuid().optional(),
@@ -12,6 +12,9 @@ export const transactionSchema = z.object({
   isRecurring: z.coerce.boolean().default(false),
   recurrenceRule: z.string().optional(),
   tagIds: z.string().optional(), // comma-separated UUIDs from form
+  transferToId: z.string().uuid().optional(),
+  recurrenceInterval: z.coerce.number().int().positive().optional(),
+  recurrenceUnit: z.enum(['day', 'week', 'month']).optional(),
 })
 
 export type TransactionInput = z.infer<typeof transactionSchema>


### PR DESCRIPTION
## Summary

Three improvements to schema completeness and agent triage capability.

### 1. Credit card as a first-class account type

**Schema changes:**
- `credit_card` added to `account_type` enum
- `credit_limit`, `statement_day`, `payment_due_day` columns added to `accounts`
- `credit_payment` added to `transaction_type` enum

**Balance semantics for credit cards:**
- Balance = `openingBalance + SUM(expenses) - SUM(credit_payments)` (opposite polarity to normal accounts)
- Positive balance = you owe this much
- `credit_payment` type correctly models paying off a card from a bank account — it is NOT counted as an expense

**UI:**
- Credit card accounts show balance as "outstanding" in red
- Utilisation progress bar shown when credit limit is set
- Account detail page shows "Outstanding:" label and correct running balance direction
- Settings → Accounts form shows credit limit, statement day, payment due day fields when Credit Card type is selected

### 2. `credit_payment` transaction type

Paying a credit card bill from your bank account:
- Deducts from the bank account (correct)
- Reduces the credit card outstanding (correct)
- Is NOT counted as an expense in budget calculations (correct)

Previously this was impossible to model correctly — you'd have to record it as a transfer which didn't reduce the credit card outstanding.

### 3. Enriched `/api/v1/summary`

An agent calling this endpoint now gets everything needed for full financial triage:

```json
{
  "upcomingObligations": [
    { "type": "loan_emi", "name": "Home Loan", "amount": 28000, "dueDate": "2026-05-05", "daysUntil": 2 },
    { "type": "insurance_renewal", "name": "LIC Term Plan", "amount": 12000, "dueDate": "2026-05-15", "daysUntil": 12 },
    { "type": "investment_maturity", "name": "SBI FD", "estimatedValue": 550000, "dueDate": "2026-05-20", "daysUntil": 17 }
  ],
  "investments": [
    { "name": "HDFC Flexi Cap", "currentValue": 145000, "costBasis": 120000, "unrealisedPnl": 25000, "unrealisedPnlPct": 20.8 }
  ],
  "creditCards": [
    { "name": "HDFC Regalia", "outstanding": 18500, "currency": "INR" }
  ],
  "meta": {
    "totalCreditOutstanding": 18500,
    "totalUpcomingObligations30d": 40000,
    "totalInvestmentValue": 145000,
    "totalUnrealisedPnl": 25000
  }
}
```

Previously the summary only covered cash accounts + budgets. Now a single API call gives complete financial state.

### Migration

Run after merging:
```bash
ssh personal 'bash /opt/ledgerify/run-migration.sh'
```
Or apply `drizzle/0002_lush_frightful_four.sql` directly.