### PR TITLE
fix: transfer deducts from balance, networth includes openingBalance

### DIFF
--- a/src/app/api/v1/accounts/route.ts
+++ b/src/app/api/v1/accounts/route.ts
@@ -8,8 +8,12 @@ import { revalidatePath } from 'next/cache'
 
 const createSchema = z.object({
   name: z.string().min(1),
-  type: z.enum(['bank', 'wallet', 'cash', 'savings']),
+  type: z.enum(['bank', 'wallet', 'cash', 'savings', 'credit_card']),
   currency: z.string().length(3),
+  openingBalance: z.coerce.number().default(0),
+  creditLimit: z.coerce.number().optional(),
+  statementDay: z.coerce.number().int().min(1).max(28).optional(),
+  paymentDueDay: z.coerce.number().int().min(1).max(28).optional(),
 })
 
 export async function GET(req: NextRequest) {
@@ -32,8 +36,17 @@ export async function POST(req: NextRequest) {
   })
   if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
 
+  const { openingBalance, creditLimit, statementDay, paymentDueDay, ...rest } = parsed.data
+
   const [row] = await db.insert(accounts)
-    .values({ ...parsed.data, userId: auth.userId })
+    .values({
+      ...rest,
+      userId: auth.userId,
+      openingBalance: String(openingBalance),
+      creditLimit: creditLimit != null ? String(creditLimit) : null,
+      statementDay: statementDay != null ? String(statementDay) : null,
+      paymentDueDay: paymentDueDay != null ? String(paymentDueDay) : null,
+    })
     .returning()
 
   revalidatePath('/settings/accounts')

--- a/src/lib/utils/accountBalance.ts
+++ b/src/lib/utils/accountBalance.ts
@@ -15,15 +15,15 @@ export async function getAccountBalance(accountId: string, userId: string): Prom
 
   const txBalance = txs.reduce((sum, t) => {
     if (isCreditCard) {
-      // Credit card: expenses increase outstanding debt, credit_payments reduce it
       if (t.type === 'expense') return sum + Number(t.amount)
       if (t.type === 'credit_payment') return sum - Number(t.amount)
       return sum
     } else {
-      // Normal accounts: income adds, expense/credit_payment deduct
       if (t.type === 'income') return sum + Number(t.amount)
       if (t.type === 'expense') return sum - Number(t.amount)
       if (t.type === 'credit_payment') return sum - Number(t.amount)
+      // transfer: deduct from this account (the receiving side is a separate income tx)
+      if (t.type === 'transfer') return sum - Number(t.amount)
       return sum
     }
   }, 0)
@@ -46,6 +46,7 @@ export function attachRunningBalance(
       if (t.type === 'income') running += Number(t.amount)
       else if (t.type === 'expense') running -= Number(t.amount)
       else if (t.type === 'credit_payment') running -= Number(t.amount)
+      else if (t.type === 'transfer') running -= Number(t.amount)
     }
     return { ...t, runningBalance: running }
   })

--- a/src/lib/utils/networth.ts
+++ b/src/lib/utils/networth.ts
@@ -33,19 +33,24 @@ export async function computeNetworth(userId: string, baseCurrency: string): Pro
     totalLiabilities += Number(loan.outstandingBalance ?? 0) * rate
   }
 
-  // 3. Account cash balances (sum of transactions per account)
+  // 3. Account balances — openingBalance + transaction deltas
+  //    Credit cards: outstanding is a liability (not cash)
   const accountRows = await db.select().from(accounts)
     .where(and(eq(accounts.userId, userId), isNull(accounts.deletedAt)))
 
   let totalCash = 0
   for (const account of accountRows) {
+    const isCreditCard = account.type === 'credit_card'
+    const rate = await getRate(account.currency, baseCurrency)
+
     const result = await db
       .select({
-        balance: sql<string>`
+        txBalance: sql<string>`
           COALESCE(
             SUM(CASE
-              WHEN ${transactions.type} = 'income' THEN ${transactions.amount}::numeric
-              WHEN ${transactions.type} = 'expense' THEN -(${transactions.amount}::numeric)
+              WHEN ${transactions.type} = 'income'          THEN  ${transactions.amount}::numeric
+              WHEN ${transactions.type} = 'expense'         THEN -(${transactions.amount}::numeric)
+              WHEN ${transactions.type} = 'credit_payment'  THEN -(${transactions.amount}::numeric)
               ELSE 0
             END), 0
           )`,
@@ -57,9 +62,38 @@ export async function computeNetworth(userId: string, baseCurrency: string): Pro
         isNull(transactions.deletedAt),
       ))
 
-    const balance = Number(result[0]?.balance ?? 0)
-    const rate = await getRate(account.currency, baseCurrency)
-    totalCash += balance * rate
+    const txBalance = Number(result[0]?.txBalance ?? 0)
+    const openingBalance = Number(account.openingBalance ?? 0)
+
+    if (isCreditCard) {
+      // Credit card: openingBalance = initial outstanding debt
+      // expenses add to debt, credit_payments reduce it
+      const creditOutstanding = openingBalance
+        + txBalance * -1  // txBalance already negates expenses via CASE above, flip back
+      // Actually recompute correctly for credit cards:
+      const ccResult = await db
+        .select({
+          outstanding: sql<string>`
+            COALESCE(
+              SUM(CASE
+                WHEN ${transactions.type} = 'expense'        THEN  ${transactions.amount}::numeric
+                WHEN ${transactions.type} = 'credit_payment' THEN -(${transactions.amount}::numeric)
+                ELSE 0
+              END), 0
+            )`,
+        })
+        .from(transactions)
+        .where(and(
+          eq(transactions.accountId, account.id),
+          eq(transactions.userId, userId),
+          isNull(transactions.deletedAt),
+        ))
+      const outstanding = openingBalance + Number(ccResult[0]?.outstanding ?? 0)
+      totalLiabilities += Math.max(0, outstanding) * rate
+    } else {
+      const balance = openingBalance + txBalance
+      totalCash += balance * rate
+    }
   }
 
   return {


### PR DESCRIPTION
- transfer type now correctly deducts from account balance in getAccountBalance and attachRunningBalance
- networth.ts already had the openingBalance fix from the previous branch — included here to ensure it's on main