### PR TITLE
feat: category-keywords API + bulk categorise

### DIFF
--- a/src/app/api/v1/category-keywords/route.ts
+++ b/src/app/api/v1/category-keywords/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { categoryKeywords, categories } from '@/lib/db/schema'
+import { eq, and, isNull, or } from 'drizzle-orm'
+import { z } from 'zod'
+
+const createSchema = z.object({
+  categoryId: z.string().uuid(),
+  keyword: z.string().min(1).max(100).toLowerCase(),
+})
+
+const bulkSchema = z.object({
+  keywords: z.array(z.object({
+    categoryId: z.string().uuid(),
+    keyword: z.string().min(1).max(100),
+  })).min(1),
+})
+
+export async function GET(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const rows = await db.select().from(categoryKeywords)
+    .where(eq(categoryKeywords.userId, auth.userId))
+  return NextResponse.json(rows)
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const body = await req.json()
+
+  // Support both single and bulk insert
+  if (body.keywords) {
+    const parsed = bulkSchema.safeParse(body)
+    if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+    // Validate all categoryIds belong to user or are system categories
+    for (const kw of parsed.data.keywords) {
+      const cat = await db.query.categories.findFirst({
+        where: and(
+          eq(categories.id, kw.categoryId),
+          isNull(categories.deletedAt),
+          or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+        ),
+      })
+      if (!cat) return NextResponse.json({ error: `Category ${kw.categoryId} not found` }, { status: 400 })
+    }
+
+    const rows = await db.insert(categoryKeywords)
+      .values(parsed.data.keywords.map(kw => ({
+        userId: auth.userId,
+        categoryId: kw.categoryId,
+        keyword: kw.keyword.toLowerCase(),
+      })))
+      .onConflictDoNothing()
+      .returning()
+    return NextResponse.json(rows, { status: 201 })
+  }
+
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 })
+
+  const cat = await db.query.categories.findFirst({
+    where: and(
+      eq(categories.id, parsed.data.categoryId),
+      isNull(categories.deletedAt),
+      or(eq(categories.userId, auth.userId), isNull(categories.userId)),
+    ),
+  })
+  if (!cat) return NextResponse.json({ error: 'Category not found' }, { status: 400 })
+
+  const [row] = await db.insert(categoryKeywords)
+    .values({ userId: auth.userId, categoryId: parsed.data.categoryId, keyword: parsed.data.keyword.toLowerCase() })
+    .returning()
+  return NextResponse.json(row, { status: 201 })
+}
+
+export async function DELETE(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  const { searchParams } = new URL(req.url)
+  const id = searchParams.get('id')
+  if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 })
+
+  await db.delete(categoryKeywords)
+    .where(and(eq(categoryKeywords.id, id), eq(categoryKeywords.userId, auth.userId)))
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/v1/transactions/categorise/route.ts
+++ b/src/app/api/v1/transactions/categorise/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resolveSession } from '@/lib/api/auth'
+import { db } from '@/lib/db'
+import { transactions, categoryKeywords } from '@/lib/db/schema'
+import { eq, and, isNull } from 'drizzle-orm'
+import { revalidatePath } from 'next/cache'
+
+/**
+ * POST /api/v1/transactions/categorise
+ * Applies auto-categorisation to ALL transactions that have no categoryId.
+ * Uses the user's category_keywords rules.
+ */
+export async function POST(req: NextRequest) {
+  const auth = await resolveSession(req)
+  if (auth instanceof NextResponse) return auth
+
+  // Load all keywords for user
+  const keywords = await db.select().from(categoryKeywords)
+    .where(eq(categoryKeywords.userId, auth.userId))
+
+  if (keywords.length === 0) return NextResponse.json({ updated: 0, message: 'No keywords configured' })
+
+  // Load all uncategorised transactions
+  const uncategorised = await db.select().from(transactions)
+    .where(and(
+      eq(transactions.userId, auth.userId),
+      isNull(transactions.categoryId),
+      isNull(transactions.deletedAt),
+    ))
+
+  let updated = 0
+  for (const txn of uncategorised) {
+    const title = (txn.title || txn.note || '').toLowerCase()
+    if (!title) continue
+
+    const match = keywords.find(kw => title.includes(kw.keyword.toLowerCase()))
+    if (match) {
+      await db.update(transactions)
+        .set({ categoryId: match.categoryId })
+        .where(eq(transactions.id, txn.id))
+      updated++
+    }
+  }
+
+  revalidatePath('/transactions')
+  revalidatePath('/dashboard')
+  revalidatePath('/reports/category-breakdown')
+  revalidatePath('/budgets')
+  return NextResponse.json({ updated, total: uncategorised.length })
+}

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -9,11 +9,12 @@ import { revalidatePath } from 'next/cache'
 
 const createSchema = z.object({
   accountId: z.string().uuid(),
-  type: z.enum(['income', 'expense']),
+  type: z.enum(['income', 'expense', 'transfer', 'credit_payment']),
   amount: z.coerce.number().positive(),
   currency: z.string().length(3),
   categoryId: z.string().uuid().optional(),
   note: z.string().max(500).optional(),
+  title: z.string().max(255).optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   isRecurring: z.coerce.boolean().default(false),
 })


### PR DESCRIPTION
- POST/GET/DELETE /api/v1/category-keywords (single + bulk insert)
- POST /api/v1/transactions/categorise — applies keyword rules to all uncategorised transactions