### PR TITLE
fix: CI Go build/vet + AuthHandler Querier consolidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,26 @@ jobs:
         run: bun run build
         env:
           # Dummy env vars so build doesn't fail without a real DB
-          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+          DATABASE_URL: postgresql://dummy:***@localhost:5432/dummy
           AUTH_SECRET: dummy-secret-for-ci-build-only-32chars
           AUTH_URL: http://localhost:3000
           NEXT_PUBLIC_APP_URL: http://localhost:3000
           CRON_SECRET: dummy-cron-secret
+
+  go-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -17,10 +17,11 @@ import (
 type AuthHandler struct {
 	pool   *pgxpool.Pool
 	jwtCfg *auth.JWTConfig
+	q      db.Querier
 }
 
 func NewAuthHandler(pool *pgxpool.Pool, jwtCfg *auth.JWTConfig) *AuthHandler {
-	return &AuthHandler{pool: pool, jwtCfg: jwtCfg}
+	return &AuthHandler{pool: pool, jwtCfg: jwtCfg, q: db.New(pool)}
 }
 
 type authRegisterRequest struct {
@@ -80,13 +81,12 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := db.New(h.pool)
 	defaultCurrency := req.DefaultCurrency
 	if defaultCurrency == "" {
 		defaultCurrency = "USD"
 	}
 
-	user, err := q.CreateUser(r.Context(), db.CreateUserParams{
+	user, err :=	h.q.CreateUser(r.Context(),db.CreateUserParams{
 		Email:           req.Email,
 		PasswordHash:    string(hash),
 		Name:            req.Name,
@@ -129,8 +129,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := db.New(h.pool)
-	user, err := q.GetUserByEmail(r.Context(), req.Email)
+	user, err := h.q.GetUserByEmail(r.Context(), req.Email)
 	if err != nil {
 		utils.BadRequest(w, "invalid email or password")
 		return
@@ -167,9 +166,8 @@ func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := db.New(h.pool)
 	userUUID := stringToUUID(claims.UserID)
-	user, err := q.GetUserByID(r.Context(), userUUID)
+	user, err := h.q.GetUserByID(r.Context(), userUUID)
 	if err != nil {
 		utils.InternalError(w)
 		return


### PR DESCRIPTION
Stacked on #24.

**Changes:**
- Adds Go build and vet steps to CI workflow (previously Go changes weren't validated)
- Refactors AuthHandler to use `h.q` (shared Querier) instead of creating a new `db.New(h.pool)` per method, consistent with all other handlers

**Before/After (AuthHandler):**
```diff
- q := db.New(h.pool)
- user, err := q.GetUserByEmail(ctx, email)
+ user, err := h.q.GetUserByEmail(ctx, email)
```