### PR TITLE
feat: wire Go API server into production deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  GO_IMAGE_NAME: ${{ github.repository }}-go
 
 jobs:
   build-and-deploy:
@@ -43,7 +44,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
+      - name: Extract Docker metadata (Next.js)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -52,13 +53,32 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
 
-      - name: Build and push Docker image
+      - name: Build and push Next.js image
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract Docker metadata (Go API)
+        id: meta-go
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.GO_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push Go API image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.goserver
+          push: true
+          tags: ${{ steps.meta-go.outputs.tags }}
+          labels: ${{ steps.meta-go.outputs.labels }}
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1

--- a/Dockerfile.goserver
+++ b/Dockerfile.goserver
@@ -1,0 +1,24 @@
+# Stage 1: Build
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+
+# Cache module downloads separately from source
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /server ./cmd/server
+
+# Stage 2: Minimal runner
+FROM alpine:3.21 AS runner
+RUN apk add --no-cache ca-certificates tzdata
+
+RUN addgroup -S ledgerify && adduser -S ledgerify -G ledgerify
+
+COPY --from=builder --chown=ledgerify:ledgerify /server /server
+
+USER ledgerify
+EXPOSE 8080
+ENV PORT=8080
+
+CMD ["/server"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,20 @@ services:
       postgres:
         condition: service_healthy
 
+  go-api:
+    image: ghcr.io/kts-o7/ledgerify-web-go:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      JWT_SECRET: ${AUTH_SECRET}
+      FRONTEND_URL: ${NEXT_PUBLIC_APP_URL}
+      PORT: "8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   postgres:
     image: postgres:17-alpine
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Stacked on #26 (which stacks on #24)
- Adds `Dockerfile.go`: multi-stage build (`golang:1.26-alpine` → `alpine:3.21`), unprivileged user, binary at `/server`, exposes 8080
- Adds `go-api` service to `docker-compose.prod.yml` on `127.0.0.1:8080:8080` with `DATABASE_URL`, `JWT_SECRET` (mapped from `AUTH_SECRET`), `FRONTEND_URL`; depends on postgres health check
- Updates `deploy.yml` to build and push `ghcr.io/kts-o7/ledgerify-web-go:latest` from `Dockerfile.go` alongside the existing Next.js image; VPS deploy step pulls and restarts both containers

## Nginx (manual VPS step)
Add before the existing `location /` block in `/etc/nginx/sites-available/money.shenthar.me`:
```nginx
location /api/ {
    proxy_pass http://127.0.0.1:8080;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
}
```
Then `nginx -t && systemctl reload nginx`.

## Merge order
#24 → #23 → #25 → #26 → this PR