### PR TITLE
feat: sync config files to VPS on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,15 @@ jobs:
           tags: ${{ steps.meta-go.outputs.tags }}
           labels: ${{ steps.meta-go.outputs.labels }}
 
+      - name: Copy config files to VPS
+        uses: appleboy/scp-action@v0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          source: "docker-compose.prod.yml,nginx/money.shenthar.me.conf"
+          target: /opt/ledgerify-deploy
+
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1
         with:
@@ -87,6 +96,16 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
+            # Sync compose file
+            cp /opt/ledgerify-deploy/docker-compose.prod.yml /opt/ledgerify/docker-compose.prod.yml
+
+            # Sync nginx config + ensure sites-enabled is a symlink
+            sudo cp /opt/ledgerify-deploy/nginx/money.shenthar.me.conf /etc/nginx/sites-available/money.shenthar.me
+            sudo rm -f /etc/nginx/sites-enabled/money.shenthar.me
+            sudo ln -s /etc/nginx/sites-available/money.shenthar.me /etc/nginx/sites-enabled/money.shenthar.me
+            sudo nginx -t && sudo systemctl reload nginx
+
+            # Pull and restart containers
             cd /opt/ledgerify
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d --remove-orphans

--- a/nginx/money.shenthar.me.conf
+++ b/nginx/money.shenthar.me.conf
@@ -8,26 +8,38 @@ server {
     listen 443 ssl;
     server_name money.shenthar.me;
 
-    ssl_certificate     /etc/letsencrypt/live/money.shenthar.me/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/money.shenthar.me/privkey.pem;
-    include             /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+    ssl_certificate     /etc/ssl/certs/money.shenthar.me.crt;
+    ssl_certificate_key /etc/ssl/private/money.shenthar.me.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
 
-    # Go REST API
-    location /api/ {
-        proxy_pass         http://127.0.0.1:8080;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
+
+    location /_next/static/ {
+        proxy_pass http://127.0.0.1:3000;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
     }
 
-    # Next.js app
+    location /api/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
-        proxy_pass         http://127.0.0.1:3000;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
     }
 }

--- a/nginx/money.shenthar.me.conf
+++ b/nginx/money.shenthar.me.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name money.shenthar.me;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name money.shenthar.me;
+
+    ssl_certificate     /etc/letsencrypt/live/money.shenthar.me/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/money.shenthar.me/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Go REST API
+    location /api/ {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # Next.js app
+    location / {
+        proxy_pass         http://127.0.0.1:3000;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `appleboy/scp-action@v0` step to copy `docker-compose.prod.yml` and `nginx/money.shenthar.me.conf` to `/opt/ledgerify-deploy` on the VPS before running compose commands
- Deploy ssh script now syncs compose file to `/opt/ledgerify/` and installs nginx config into `sites-available`, replacing any existing `sites-enabled` entry with a proper symlink, then reloads nginx
- Adds `nginx/money.shenthar.me.conf` to the repo for version control — routes `/api/` to Go API on `:8080`, everything else to Next.js on `:3000`

## Notes
- SSL cert paths in the nginx config use the standard Let's Encrypt layout — adjust if your cert paths differ
- VPS user needs passwordless `sudo` for `cp`, `rm`, `ln`, `nginx`, `systemctl reload nginx`