### PR TITLE
fix: deploy failed — appleboy/scp-action@v0 tag doesn't exist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
           labels: ${{ steps.meta-go.outputs.labels }}
 
       - name: Copy config files to VPS
-        uses: appleboy/scp-action@v0
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}


### PR DESCRIPTION
One-line fix: v0 → v1. The scp-action repo has no bare v0 tag.