### PR TITLE
Phase 1: htmx + Go template foundation (server-rendered UI)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,10 +14,12 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	embedassets "github.com/KTS-o7/ledgerify-web"
 	"github.com/KTS-o7/ledgerify-web/internal/auth"
 	"github.com/KTS-o7/ledgerify-web/internal/db"
 	"github.com/KTS-o7/ledgerify-web/internal/handlers"
 	"github.com/KTS-o7/ledgerify-web/internal/middleware"
+	"github.com/KTS-o7/ledgerify-web/internal/templates"
 )
 
 func main() {
@@ -65,6 +67,12 @@ func main() {
 	importExportHandler := handlers.NewImportExportHandler(pool, q)
 	rateHandler := handlers.NewExchangeRateHandler(q)
 
+	// Initialize templates with embedded assets
+	templates.Init(embedassets.TemplateFS(), embedassets.StaticFS(), false)
+
+	// Page handlers
+	ph := templates.NewPageHandlers(pool, q, cq, jwtCfg)
+
 	r := chi.NewRouter()
 	r.Use(corsHandler)
 	r.Use(chimw.Logger)
@@ -72,13 +80,58 @@ func main() {
 	r.Use(chimw.RealIP)
 	r.Use(chimw.RequestID)
 	r.Use(chimw.Timeout(30 * time.Second))
-	r.Use(middleware.BodyLimit(1 << 20)) // 1MB body size limit
+	r.Use(middleware.BodyLimit(1 << 20)) // 1MB
 
+	// Static files (embedded)
+	r.Get("/static/*", templates.ServeStatic)
+
+	// Health
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	})
 
+	// === PAGE ROUTES ===
+	// Auth pages (no auth required)
+	r.Group(func(r chi.Router) {
+		r.Get("/login", ph.LoginPage)
+		r.Post("/login", ph.LoginAction)
+		r.Get("/register", ph.RegisterPage)
+		r.Post("/register", ph.RegisterAction)
+	})
+
+	// Protected page routes
+	r.Group(func(r chi.Router) {
+		r.Use(templates.PageAuthMiddleware(jwtCfg))
+
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+		})
+		r.Get("/dashboard", ph.DashboardPage)
+		r.Get("/transactions", ph.Placeholder("Transactions"))
+		r.Get("/accounts", ph.Placeholder("Accounts"))
+		r.Get("/accounts/{id}", ph.Placeholder("Account Detail"))
+		r.Get("/budgets", ph.Placeholder("Budgets"))
+		r.Get("/budgets/{id}", ph.Placeholder("Budget Detail"))
+		r.Get("/budgets/goals", ph.Placeholder("Savings Goals"))
+		r.Get("/investments", ph.Placeholder("Investments"))
+		r.Get("/loans", ph.Placeholder("Loans"))
+		r.Get("/insurance", ph.Placeholder("Insurance"))
+		r.Get("/networth", ph.Placeholder("Net Worth"))
+		r.Get("/reports", ph.Placeholder("Reports"))
+		r.Get("/reports/cash-flow", ph.Placeholder("Cash Flow"))
+		r.Get("/reports/category-breakdown", ph.Placeholder("Category Breakdown"))
+		r.Get("/reports/budget-vs-actual", ph.Placeholder("Budget vs Actual"))
+		r.Get("/reports/investment-returns", ph.Placeholder("Investment Returns"))
+		r.Get("/reports/debt-payoff", ph.Placeholder("Debt Payoff"))
+		r.Get("/import", ph.Placeholder("Import"))
+		r.Get("/settings", ph.Placeholder("Settings"))
+		r.Get("/settings/categories", ph.Placeholder("Categories"))
+		r.Get("/settings/data", ph.Placeholder("Data"))
+		r.Get("/logout", ph.LogoutAction)
+	})
+
+	// === API ROUTES ===
 	r.Route("/api/v1/auth", func(r chi.Router) {
 		r.Post("/register", authHandler.Register)
 		r.Post("/login", authHandler.Login)

--- a/embedassets.go
+++ b/embedassets.go
@@ -1,0 +1,31 @@
+package embedassets
+
+import (
+	"embed"
+	"io/fs"
+	"log"
+)
+
+//go:embed web/templates/base.html
+//go:embed web/templates/pages/*
+//go:embed web/templates/partials/*
+var templateFS embed.FS
+
+//go:embed web/static/*
+var staticFS embed.FS
+
+func init() {
+	// Verify critical templates load
+	if _, err := fs.ReadFile(templateFS, "web/templates/base.html"); err != nil {
+		log.Printf("embedassets: base.html not found in embedded FS: %v", err)
+	}
+	if _, err := fs.ReadFile(templateFS, "web/templates/pages/login.html"); err != nil {
+		log.Printf("embedassets: login.html not found in embedded FS: %v", err)
+	}
+}
+
+// TemplateFS returns the embedded template filesystem.
+func TemplateFS() fs.FS { return templateFS }
+
+// StaticFS returns the embedded static filesystem.
+func StaticFS() fs.FS { return staticFS }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -41,6 +41,12 @@ func GetUserClaims(r *http.Request) *auth.Claims {
 	return claims
 }
 
+// WithUserClaims injects claims into a context. Used by page auth middleware
+// to share claims between cookie-based and header-based auth.
+func WithUserClaims(ctx context.Context, claims *auth.Claims) context.Context {
+	return context.WithValue(ctx, claimsKey, claims)
+}
+
 func RequireAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if GetUserClaims(r) == nil {

--- a/internal/templates/funcs.go
+++ b/internal/templates/funcs.go
@@ -35,13 +35,36 @@ var funcMap = template.FuncMap{
 // formatCurrency formats a float as currency (e.g., $1,234.56).
 func formatCurrency(amount float64, currency string) string {
 	symbol := currencySymbol(currency)
-	absAmount := amount
 	sign := ""
+	absAmount := amount
 	if absAmount < 0 {
 		sign = "-"
 		absAmount = -absAmount
 	}
-	return fmt.Sprintf("%s%s%'.2f", sign, symbol, absAmount)
+	return fmt.Sprintf("%s%s%s", sign, symbol, withSeparators(fmt.Sprintf("%.2f", absAmount)))
+}
+
+// withSeparators inserts thousands commas into a formatted number string.
+func withSeparators(s string) string {
+	parts := strings.SplitN(s, ".", 2)
+	intPart := parts[0]
+	n := len(intPart)
+	if n <= 3 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(n + n/3 + len(parts) - 1)
+	for i, ch := range intPart {
+		if i > 0 && (n-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte(byte(ch))
+	}
+	if len(parts) > 1 {
+		b.WriteByte('.')
+		b.WriteString(parts[1])
+	}
+	return b.String()
 }
 
 // formatCurrencyShort formats a float as compact currency (e.g., $1.2K).
@@ -59,7 +82,7 @@ func formatCurrencyShort(amount float64, currency string) string {
 	if absAmount >= 1_000 {
 		return fmt.Sprintf("%s%s%.1fK", sign, symbol, absAmount/1_000)
 	}
-	return fmt.Sprintf("%s%s%'.0f", sign, symbol, absAmount)
+	return fmt.Sprintf("%s%s%s", sign, symbol, withSeparators(fmt.Sprintf("%.0f", absAmount)))
 }
 
 func currencySymbol(currency string) string {

--- a/internal/templates/funcs.go
+++ b/internal/templates/funcs.go
@@ -1,0 +1,207 @@
+package templates
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+	"time"
+)
+
+var funcMap = template.FuncMap{
+	"formatCurrency":      formatCurrency,
+	"formatCurrencyShort": formatCurrencyShort,
+	"formatDate":          formatDate,
+	"formatDateShort":     formatDateShort,
+	"formatPercent":       formatPercent,
+	"formatAmount":        formatAmount,
+	"amountClass":         amountClass,
+	"dict":                dict,
+	"safeHTML":            safeHTML,
+	"safeAttr":            safeAttr,
+	"add":                 add,
+	"sub":                 sub,
+	"mul":                 mul,
+	"div":                 div,
+	"eqStr":               eqStr,
+	"contains":            strings.Contains,
+	"hasPrefix":           strings.HasPrefix,
+	"now":                 time.Now,
+	"since":               time.Since,
+	"until":               time.Until,
+	"defaultStr":          defaultStr,
+	"ternary":             ternary,
+}
+
+// formatCurrency formats a float as currency (e.g., $1,234.56).
+func formatCurrency(amount float64, currency string) string {
+	symbol := currencySymbol(currency)
+	absAmount := amount
+	sign := ""
+	if absAmount < 0 {
+		sign = "-"
+		absAmount = -absAmount
+	}
+	return fmt.Sprintf("%s%s%'.2f", sign, symbol, absAmount)
+}
+
+// formatCurrencyShort formats a float as compact currency (e.g., $1.2K).
+func formatCurrencyShort(amount float64, currency string) string {
+	symbol := currencySymbol(currency)
+	sign := ""
+	absAmount := amount
+	if absAmount < 0 {
+		sign = "-"
+		absAmount = -absAmount
+	}
+	if absAmount >= 1_000_000 {
+		return fmt.Sprintf("%s%s%.1fM", sign, symbol, absAmount/1_000_000)
+	}
+	if absAmount >= 1_000 {
+		return fmt.Sprintf("%s%s%.1fK", sign, symbol, absAmount/1_000)
+	}
+	return fmt.Sprintf("%s%s%'.0f", sign, symbol, absAmount)
+}
+
+func currencySymbol(currency string) string {
+	switch strings.ToUpper(currency) {
+	case "USD":
+		return "$"
+	case "EUR":
+		return "€"
+	case "GBP":
+		return "£"
+	case "INR":
+		return "₹"
+	case "JPY":
+		return "¥"
+	case "CNY":
+		return "¥"
+	default:
+		return currency + " "
+	}
+}
+
+// formatDate formats a time as "Jan 2, 2006".
+func formatDate(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("Jan 2, 2006")
+}
+
+// formatDateShort formats a time as "01/15".
+func formatDateShort(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("01/02")
+}
+
+// formatPercent formats a float as percentage (e.g., "67%").
+func formatPercent(pct float64) string {
+	return fmt.Sprintf("%.0f%%", pct)
+}
+
+// formatAmount returns a signed amount string.
+func formatAmount(amount float64, currency string) string {
+	if amount >= 0 {
+		return "+" + formatCurrency(amount, currency)
+	}
+	return formatCurrency(amount, currency)
+}
+
+// amountClass returns "positive" or "negative" css class.
+func amountClass(amount float64) string {
+	if amount >= 0 {
+		return "positive"
+	}
+	return "negative"
+}
+
+// dict creates a map from alternating key-value pairs. Useful in templates.
+func dict(values ...any) (map[string]any, error) {
+	if len(values)%2 != 0 {
+		return nil, fmt.Errorf("dict: odd number of arguments")
+	}
+	m := make(map[string]any, len(values)/2)
+	for i := 0; i < len(values); i += 2 {
+		key, ok := values[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("dict: key %d is not a string", i)
+		}
+		m[key] = values[i+1]
+	}
+	return m, nil
+}
+
+func safeHTML(s string) template.HTML {
+	return template.HTML(s)
+}
+
+func safeAttr(s string) template.HTMLAttr {
+	return template.HTMLAttr(s)
+}
+
+func add(a, b any) float64 {
+	af := toFloat(a)
+	bf := toFloat(b)
+	return af + bf
+}
+
+func sub(a, b any) float64 {
+	af := toFloat(a)
+	bf := toFloat(b)
+	return af - bf
+}
+
+func mul(a, b any) float64 {
+	af := toFloat(a)
+	bf := toFloat(b)
+	return af * bf
+}
+
+func div(a, b any) float64 {
+	af := toFloat(a)
+	bf := toFloat(b)
+	if bf == 0 {
+		return 0
+	}
+	return af / bf
+}
+
+func eqStr(a, b string) bool {
+	return a == b
+}
+
+func defaultStr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func ternary(cond bool, a, b any) any {
+	if cond {
+		return a
+	}
+	return b
+}
+
+func toFloat(v any) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	case float32:
+		return float64(val)
+	case int:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case int32:
+		return float64(val)
+	case time.Duration:
+		return float64(val)
+	default:
+		return 0
+	}
+}

--- a/internal/templates/handlers.go
+++ b/internal/templates/handlers.go
@@ -1,0 +1,181 @@
+package templates
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/KTS-o7/ledgerify-web/internal/auth"
+	"github.com/KTS-o7/ledgerify-web/internal/db"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// PageHandlers handles serving HTML pages.
+type PageHandlers struct {
+	pool   *pgxpool.Pool
+	q      *db.Queries
+	cq     *db.CustomQueries
+	jwtCfg *auth.JWTConfig
+}
+
+// NewPageHandlers creates a new PageHandlers.
+func NewPageHandlers(pool *pgxpool.Pool, q *db.Queries, cq *db.CustomQueries, jwtCfg *auth.JWTConfig) *PageHandlers {
+	return &PageHandlers{pool: pool, q: q, cq: cq, jwtCfg: jwtCfg}
+}
+
+// LoginPage renders the login form.
+func (ph *PageHandlers) LoginPage(w http.ResponseWriter, r *http.Request) {
+	if GetUserInfo(r) != nil {
+		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+		return
+	}
+	data := NewPageData(r, "Sign In")
+	data.Flashes = GetFlashes(r)
+	http.SetCookie(w, &http.Cookie{Name: flashCookieName, Value: "", Path: "/", MaxAge: -1})
+	RenderPage(w, "login", data)
+}
+
+// RegisterPage renders the registration form.
+func (ph *PageHandlers) RegisterPage(w http.ResponseWriter, r *http.Request) {
+	if GetUserInfo(r) != nil {
+		http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+		return
+	}
+	data := NewPageData(r, "Create Account")
+	data.Flashes = GetFlashes(r)
+	http.SetCookie(w, &http.Cookie{Name: flashCookieName, Value: "", Path: "/", MaxAge: -1})
+	RenderPage(w, "register", data)
+}
+
+// LoginAction handles the login form submission.
+func (ph *PageHandlers) LoginAction(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		SetFlash(w, "error", "Invalid form data")
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	email := r.FormValue("email")
+	password := r.FormValue("password")
+
+	user, err := ph.q.GetUserByEmail(r.Context(), email)
+	if err != nil {
+		SetFlash(w, "error", "Invalid email or password")
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
+		SetFlash(w, "error", "Invalid email or password")
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	token, expiry, err := ph.jwtCfg.GenerateToken(uuid.UUID(user.ID.Bytes).String(), user.Email)
+	if err != nil {
+		SetFlash(w, "error", "Authentication error")
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	maxAge := int(time.Until(expiry).Seconds())
+	http.SetCookie(w, &http.Cookie{
+		Name:     "token",
+		Value:    token,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+}
+
+// RegisterAction handles the registration form submission.
+func (ph *PageHandlers) RegisterAction(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		SetFlash(w, "error", "Invalid form data")
+		http.Redirect(w, r, "/register", http.StatusSeeOther)
+		return
+	}
+
+	email := r.FormValue("email")
+	password := r.FormValue("password")
+	name := r.FormValue("name")
+
+	if email == "" || password == "" || name == "" {
+		SetFlash(w, "error", "All fields are required")
+		http.Redirect(w, r, "/register", http.StatusSeeOther)
+		return
+	}
+
+	if len(password) < 6 {
+		SetFlash(w, "error", "Password must be at least 6 characters")
+		http.Redirect(w, r, "/register", http.StatusSeeOther)
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		SetFlash(w, "error", "Registration error")
+		http.Redirect(w, r, "/register", http.StatusSeeOther)
+		return
+	}
+
+	user, err := ph.q.CreateUser(r.Context(), db.CreateUserParams{
+		Email:        email,
+		PasswordHash: string(hash),
+		Name:         name,
+	})
+	if err != nil {
+		SetFlash(w, "error", "Email already registered")
+		http.Redirect(w, r, "/register", http.StatusSeeOther)
+		return
+	}
+
+	token, expiry, err := ph.jwtCfg.GenerateToken(uuid.UUID(user.ID.Bytes).String(), user.Email)
+	if err != nil {
+		SetFlash(w, "error", "Registration error")
+		http.Redirect(w, r, "/register", http.StatusSeeOther)
+		return
+	}
+
+	maxAge := int(time.Until(expiry).Seconds())
+	http.SetCookie(w, &http.Cookie{
+		Name:     "token",
+		Value:    token,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
+}
+
+// DashboardPage renders the dashboard.
+func (ph *PageHandlers) DashboardPage(w http.ResponseWriter, r *http.Request) {
+	data := NewPageData(r, "Dashboard")
+	RenderPage(w, "placeholder", data)
+}
+
+// Placeholder returns a handler that renders the placeholder page.
+func (ph *PageHandlers) Placeholder(title string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := NewPageData(r, title)
+		RenderPage(w, "placeholder", data)
+	}
+}
+
+// LogoutAction clears the JWT cookie and redirects to login.
+func (ph *PageHandlers) LogoutAction(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "token",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+	})
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
+}

--- a/internal/templates/pages.go
+++ b/internal/templates/pages.go
@@ -1,0 +1,133 @@
+package templates
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/KTS-o7/ledgerify-web/internal/auth"
+	"github.com/KTS-o7/ledgerify-web/internal/middleware"
+)
+
+// PageAuthMiddleware checks for JWT in cookie or Authorization header.
+// If valid, injects claims into context and passes through.
+// If invalid/absent and the path is not an auth page, redirects to /login.
+func PageAuthMiddleware(jwtCfg *auth.JWTConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Skip auth for static assets and auth pages
+			path := r.URL.Path
+			if strings.HasPrefix(path, "/static/") || path == "/login" || path == "/register" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			var tokenStr string
+
+			// Check cookie first
+			cookie, err := r.Cookie("token")
+			if err == nil && cookie.Value != "" {
+				tokenStr = cookie.Value
+			}
+
+			// Fallback to Authorization header
+			if tokenStr == "" {
+				header := r.Header.Get("Authorization")
+				if strings.HasPrefix(header, "Bearer ") {
+					tokenStr = header[7:]
+				}
+			}
+
+			if tokenStr == "" {
+				// API paths return JSON error, page paths redirect
+				if strings.HasPrefix(path, "/api/") {
+					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+					return
+				}
+				http.Redirect(w, r, "/login", http.StatusSeeOther)
+				return
+			}
+
+			claims, err := jwtCfg.ValidateToken(tokenStr)
+			if err != nil {
+				if strings.HasPrefix(path, "/api/") {
+					http.Error(w, `{"error":"invalid or expired token"}`, http.StatusUnauthorized)
+					return
+				}
+				// Clear invalid cookie and redirect
+				http.SetCookie(w, &http.Cookie{
+					Name:     "token",
+					Value:    "",
+					Path:     "/",
+					MaxAge:   -1,
+					HttpOnly: true,
+				})
+				http.Redirect(w, r, "/login", http.StatusSeeOther)
+				return
+			}
+
+			// Inject claims into context (same pattern as existing middleware)
+			r = r.WithContext(middleware.WithUserClaims(r.Context(), claims))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// GetTheme returns the current theme from cookie or defaults to "dark".
+func GetTheme(r *http.Request) string {
+	cookie, err := r.Cookie("theme")
+	if err == nil && cookie.Value == "light" {
+		return "light"
+	}
+	return "dark"
+}
+
+// GetUserInfo extracts user info from the request context.
+// Returns nil if not authenticated.
+func GetUserInfo(r *http.Request) *UserInfo {
+	claims := middleware.GetUserClaims(r)
+	if claims == nil {
+		return nil
+	}
+	return &UserInfo{
+		ID:    claims.UserID,
+		Email: claims.Email,
+	}
+}
+
+// NewPageData creates a PageData struct from the request.
+func NewPageData(r *http.Request, title string) PageData {
+	theme := GetTheme(r)
+	user := GetUserInfo(r)
+	return PageData{
+		Title:       title,
+		User:        user,
+		CurrentPath: r.URL.Path,
+		Theme:       theme,
+	}
+}
+
+// Flash helpers
+const flashCookieName = "ledgerify_flash"
+
+func SetFlash(w http.ResponseWriter, flashType, message string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     flashCookieName,
+		Value:    flashType + ":" + message,
+		Path:     "/",
+		MaxAge:   60, // 1 minute
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func GetFlashes(r *http.Request) []Flash {
+	cookie, err := r.Cookie(flashCookieName)
+	if err != nil {
+		return nil
+	}
+	parts := strings.SplitN(cookie.Value, ":", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	return []Flash{{Type: parts[0], Message: parts[1]}}
+}

--- a/internal/templates/render.go
+++ b/internal/templates/render.go
@@ -1,0 +1,213 @@
+package templates
+
+import (
+	"fmt"
+	"html/template"
+	"io/fs"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+var (
+	// Set by Init from main
+	templateFS fs.FS
+	staticFS   fs.FS
+
+	cache     map[string]*template.Template
+	cacheMu   sync.RWMutex
+	useEmbed  bool
+)
+
+// Init initializes the template cache with the given filesystems.
+func Init(tFS, sFS fs.FS, devMode bool) {
+	templateFS = tFS
+	staticFS = sFS
+	cache = make(map[string]*template.Template)
+	useEmbed = !devMode
+}
+
+// PageData is the common data passed to every page template.
+type PageData struct {
+	Title       string
+	User        *UserInfo
+	CurrentPath string
+	Theme       string // "dark" or "light"
+	Data        any    // page-specific data
+	Flashes     []Flash
+}
+
+type UserInfo struct {
+	ID              string
+	Email           string
+	Name            string
+	DefaultCurrency string
+	Timezone        string
+}
+
+type Flash struct {
+	Type    string // "success", "error", "info"
+	Message string
+}
+
+// RenderPage renders a full page (base.html + page template).
+func RenderPage(w http.ResponseWriter, page string, data PageData) {
+	tmpl, err := getTemplate(page)
+	if err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.ExecuteTemplate(w, "base.html", data); err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// RenderPartial renders a partial template (for htmx responses).
+func RenderPartial(w http.ResponseWriter, partial string, data any) {
+	tmpl, err := getPartial(partial)
+	if err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tmpl.Execute(w, data); err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// getTemplate returns the cached template for a page, or compiles it.
+func getTemplate(page string) (*template.Template, error) {
+	cacheMu.RLock()
+	tmpl, ok := cache[page]
+	cacheMu.RUnlock()
+	if ok {
+		return tmpl, nil
+	}
+
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if tmpl, ok = cache[page]; ok {
+		return tmpl, nil
+	}
+
+	baseContent, err := fs.ReadFile(templateFS, "web/templates/base.html")
+	if err != nil {
+		return nil, fmt.Errorf("reading base.html: %w", err)
+	}
+	partialsContent := readAllPartials()
+	pageContent, err := fs.ReadFile(templateFS, "web/templates/pages/"+page+".html")
+	if err != nil {
+		return nil, fmt.Errorf("reading page %s: %w", page, err)
+	}
+
+	tmpl = template.New("base.html").Funcs(funcMap)
+	_, err = tmpl.Parse(string(baseContent))
+	if err != nil {
+		return nil, fmt.Errorf("parsing base.html: %w", err)
+	}
+	_, err = tmpl.Parse(string(partialsContent))
+	if err != nil {
+		return nil, fmt.Errorf("parsing partials: %w", err)
+	}
+	_, err = tmpl.Parse(string(pageContent))
+	if err != nil {
+		return nil, fmt.Errorf("parsing page %s: %w", page, err)
+	}
+
+	cache[page] = tmpl
+	return tmpl, nil
+}
+
+func readAllPartials() []byte {
+	var all []byte
+	entries, err := fs.ReadDir(templateFS, "web/templates/partials")
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() && filepathExt(e.Name()) == ".html" {
+			data, err := fs.ReadFile(templateFS, "web/templates/partials/"+e.Name())
+			if err != nil {
+				continue
+			}
+			all = append(all, data...)
+		}
+	}
+	return all
+}
+
+func filepathExt(name string) string {
+	for i := len(name) - 1; i >= 0; i-- {
+		if name[i] == '.' {
+			return name[i:]
+		}
+	}
+	return ""
+}
+
+// getPartial returns a cached partial template.
+func getPartial(name string) (*template.Template, error) {
+	cacheKey := "partial:" + name
+	cacheMu.RLock()
+	tmpl, ok := cache[cacheKey]
+	cacheMu.RUnlock()
+	if ok {
+		return tmpl, nil
+	}
+
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	if tmpl, ok = cache[cacheKey]; ok {
+		return tmpl, nil
+	}
+
+	content, err := fs.ReadFile(templateFS, "web/templates/partials/"+name+".html")
+	if err != nil {
+		return nil, fmt.Errorf("reading partial %s: %w", name, err)
+	}
+
+	tmpl = template.New(name).Funcs(funcMap)
+	_, err = tmpl.Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("parsing partial %s: %w", name, err)
+	}
+
+	cache[cacheKey] = tmpl
+	return tmpl, nil
+}
+
+// StaticHandler serves embedded static files (CSS, JS).
+func StaticHandler() http.Handler {
+	if staticFS != nil {
+		// Use embedded
+		sub, err := fs.Sub(staticFS, "web/static")
+		if err != nil {
+			panic("static files not found: " + err.Error())
+		}
+		return http.FileServer(http.FS(sub))
+	}
+	// Dev mode: use local filesystem
+	return http.FileServer(http.Dir("web/static"))
+}
+
+// ServeStatic is a convenience handler for /static/ prefix.
+func ServeStatic(w http.ResponseWriter, r *http.Request) {
+	// Strip /static/ prefix
+	r.URL.Path = r.URL.Path[len("/static"):]
+	StaticHandler().ServeHTTP(w, r)
+}
+
+// Now returns the current time. Used in templates for copyright year.
+func Now() time.Time { return time.Now() }
+
+func init() {
+	cache = make(map[string]*template.Template)
+	// Check if we're in development (web/ directory exists)
+	if _, err := os.Stat("web/templates"); err == nil {
+		useEmbed = false
+	}
+}

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1,0 +1,370 @@
+/* ============================================
+   Ledgerify — Custom Styles (on top of Pico.css)
+   Dark-first. Both themes supported.
+   ============================================ */
+
+/* === CSS Variables === */
+:root {
+    --sidebar-width: 240px;
+    --header-height: 60px;
+    --brand-bg: #1a1a2e;
+    --brand-accent: #6c63ff;
+    --positive: #22c55e;
+    --negative: #ef4444;
+    --card-radius: 12px;
+}
+
+[data-theme="light"] {
+    --brand-bg: #f0f0ff;
+}
+
+/* === Layout === */
+.app-layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+/* === Sidebar === */
+.sidebar {
+    width: var(--sidebar-width);
+    min-width: var(--sidebar-width);
+    background: var(--brand-bg);
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 100;
+    overflow-y: auto;
+    border-right: 1px solid var(--pico-muted-border-color, rgba(255,255,255,.08));
+}
+
+.sidebar-brand {
+    padding: 1.25rem 1rem;
+    border-bottom: 1px solid var(--pico-muted-border-color, rgba(255,255,255,.08));
+}
+
+.brand-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none !important;
+    color: var(--pico-color, #fff) !important;
+    font-weight: 700;
+    font-size: 1.2rem;
+}
+
+.brand-icon { font-size: 1.4rem; }
+
+.sidebar-links {
+    display: flex;
+    flex-direction: column;
+    padding: 0.75rem 0;
+    flex: 1;
+}
+
+.nav-link {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.6rem 1.25rem;
+    color: var(--pico-muted-color, #999) !important;
+    text-decoration: none !important;
+    font-size: 0.9rem;
+    border-left: 3px solid transparent;
+    transition: all 0.15s;
+}
+
+.nav-link:hover {
+    color: var(--pico-color, #fff) !important;
+    background: rgba(255,255,255,.05);
+}
+
+.nav-link.active {
+    color: var(--pico-color, #fff) !important;
+    background: rgba(108, 99, 255, .12);
+    border-left-color: var(--brand-accent);
+    font-weight: 600;
+}
+
+.nav-icon { font-size: 1.1rem; width: 1.3rem; text-align: center; }
+
+.nav-divider {
+    margin: 0.5rem 1rem;
+    border-color: var(--pico-muted-border-color, rgba(255,255,255,.08));
+}
+
+.nav-logout { margin-top: auto; color: var(--pico-del-color, #e55) !important; }
+
+.mobile-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--pico-color);
+    font-size: 1.5rem;
+    padding: 0.5rem;
+    cursor: pointer;
+}
+
+/* === Main Content === */
+.main-content {
+    margin-left: var(--sidebar-width);
+    flex: 1;
+    padding: 1.5rem 2rem;
+    min-height: 100vh;
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.page-header h1 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.header-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.theme-toggle {
+    background: none;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 8px;
+    padding: 0.4rem 0.6rem;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.theme-toggle:hover { background: var(--pico-muted-border-color); }
+
+/* === Dashboard Cards === */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.dashboard-card {
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-card-border-color);
+    border-radius: var(--card-radius);
+    padding: 1.25rem;
+}
+
+.dashboard-card .card-label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.25rem;
+}
+
+.dashboard-card .card-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.dashboard-card .card-sub {
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    margin-top: 0.25rem;
+}
+
+/* === Amount Colors === */
+.amount-positive, .positive { color: var(--positive) !important; }
+.amount-negative, .negative { color: var(--negative) !important; }
+.amount-zero { color: var(--pico-muted-color) !important; }
+
+/* === Budget Progress Bar === */
+.budget-bar {
+    width: 100%;
+    height: 8px;
+    background: var(--pico-muted-border-color);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 0.3rem;
+}
+
+.budget-bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.budget-bar-fill.safe { background: var(--positive); }
+.budget-bar-fill.warning { background: #f59e0b; }
+.budget-bar-fill.danger { background: var(--negative); }
+
+/* === Transactions Table === */
+.txn-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.txn-table th {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--pico-muted-color);
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+.txn-table td {
+    padding: 0.6rem 0.75rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+    font-size: 0.9rem;
+}
+
+.txn-row:hover { background: var(--pico-muted-border-color, rgba(255,255,255,.02)); }
+
+/* === Flash Messages === */
+.flashes {
+    margin-bottom: 1rem;
+}
+
+.flash {
+    padding: 0.75rem 1rem;
+    border-radius: var(--card-radius);
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.flash-success { background: rgba(34,197,94,.12); color: var(--positive); border: 1px solid rgba(34,197,94,.3); }
+.flash-error { background: rgba(239,68,68,.12); color: var(--negative); border: 1px solid rgba(239,68,68,.3); }
+.flash-info { background: rgba(59,130,246,.12); color: #3b82f6; border: 1px solid rgba(59,130,246,.3); }
+
+/* === Forms === */
+.form-inline {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.form-inline .field { flex: 1; min-width: 150px; }
+
+.form-inline .field label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.2rem;
+}
+
+/* === Modal === */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+}
+
+.modal-content {
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-card-border-color);
+    border-radius: var(--card-radius);
+    padding: 1.5rem;
+    min-width: 400px;
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.modal-header h2 { margin: 0; font-size: 1.2rem; }
+
+/* === Charts Container === */
+.chart-container {
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-card-border-color);
+    border-radius: var(--card-radius);
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.chart-container canvas {
+    max-height: 400px;
+}
+
+/* === Utilities === */
+[x-cloak] { display: none !important; }
+
+.htmx-indicator { opacity: 0; transition: opacity .2s; }
+.htmx-request .htmx-indicator { opacity: 1; }
+.htmx-request.htmx-indicator { opacity: 1; }
+
+.spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid var(--pico-muted-border-color);
+    border-top-color: var(--brand-accent);
+    border-radius: 50%;
+    animation: spin .6s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--pico-muted-color);
+}
+
+.empty-state .empty-icon { font-size: 3rem; margin-bottom: 0.5rem; }
+.empty-state p { font-size: 1rem; }
+
+.section-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.75rem;
+}
+
+.two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+/* === Responsive === */
+@media (max-width: 768px) {
+    .sidebar {
+        width: 100%;
+        min-width: 100%;
+        height: auto;
+        position: relative;
+        border-right: none;
+        border-bottom: 1px solid var(--pico-muted-border-color);
+    }
+
+    .mobile-toggle { display: block; position: absolute; right: 1rem; top: 1rem; }
+
+    .sidebar-links { display: none; }
+    .sidebar-links.open { display: flex; }
+
+    .main-content { margin-left: 0; padding: 1rem; }
+    .card-grid { grid-template-columns: 1fr; }
+    .two-col { grid-template-columns: 1fr; }
+    .modal-content { min-width: 0; }
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="{{.Theme}}" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Title}} — Ledgerify</title>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <!-- Pico.css -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <!-- Custom styles -->
+    <link rel="stylesheet" href="/static/css/custom.css">
+    <!-- htmx -->
+    <script src="https://unpkg.com/htmx.org@2.0.4" defer></script>
+    <!-- Alpine.js -->
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="h-full" hx-boost="true">
+    <div class="app-layout">
+        {{template "nav.html" .}}
+        <main class="main-content">
+            <header class="page-header">
+                <h1>{{.Title}}</h1>
+                <div class="header-actions">
+                    <button class="theme-toggle" 
+                            aria-label="Toggle theme"
+                            @click="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'; $dispatch('theme-changed')">
+                        <span class="icon-sun" x-show="document.documentElement.dataset.theme === 'dark'">☀️</span>
+                        <span class="icon-moon" x-show="document.documentElement.dataset.theme === 'light'" x-cloak>🌙</span>
+                    </button>
+                </div>
+            </header>
+
+            {{if .Flashes}}
+            <div class="flashes">
+                {{range .Flashes}}
+                <article class="flash flash-{{.Type}}">{{.Message}}</article>
+                {{end}}
+            </div>
+            {{end}}
+
+            {{template "content" .}}
+        </main>
+    </div>
+
+    <!-- Alpine theme init -->
+    <script>
+        document.addEventListener('alpine:init', () => {
+            // Theme toggle persistence via cookie
+            document.addEventListener('theme-changed', () => {
+                const theme = document.documentElement.dataset.theme;
+                document.cookie = 'theme=' + theme + ';path=/;max-age=31536000;SameSite=Lax';
+            });
+        });
+    </script>
+</body>
+</html>

--- a/web/templates/pages/login.html
+++ b/web/templates/pages/login.html
@@ -1,0 +1,56 @@
+{{define "content"}}
+<div class="auth-page" x-data="{ email: '', password: '' }">
+    <div class="auth-card">
+        <h2>Welcome back</h2>
+        <p class="auth-subtitle">Sign in to your Ledgerify account</p>
+
+        {{if .Flashes}}
+        <div class="flashes">
+            {{range .Flashes}}
+            <article class="flash flash-{{.Type}}">{{.Message}}</article>
+            {{end}}
+        </div>
+        {{end}}
+
+        <form hx-post="/login" hx-target="body" hx-push-url="false" method="POST">
+            <label>
+                Email
+                <input type="email" name="email" x-model="email" required autofocus 
+                       placeholder="you@example.com" autocomplete="email">
+            </label>
+            <label>
+                Password
+                <input type="password" name="password" x-model="password" required 
+                       placeholder="••••••••" autocomplete="current-password">
+            </label>
+            <button type="submit" class="w-full">Sign in</button>
+        </form>
+
+        <p class="auth-footer">
+            Don't have an account? <a href="/register">Create one</a>
+        </p>
+    </div>
+</div>
+
+<style>
+.auth-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: calc(100vh - 4rem);
+    margin: 0;
+}
+.auth-card {
+    width: 100%;
+    max-width: 400px;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-card-border-color);
+    border-radius: 12px;
+    padding: 2rem;
+}
+.auth-card h2 { margin: 0 0 0.25rem; }
+.auth-subtitle { color: var(--pico-muted-color); margin-bottom: 1.5rem; font-size: 0.95rem; }
+.auth-footer { text-align: center; margin-top: 1.5rem; font-size: 0.9rem; color: var(--pico-muted-color); }
+.w-full { width: 100%; }
+</style>
+{{end}}

--- a/web/templates/pages/placeholder.html
+++ b/web/templates/pages/placeholder.html
@@ -1,0 +1,7 @@
+{{define "content"}}
+<div class="empty-state">
+    <div class="empty-icon">🏗️</div>
+    <p>This page is under construction.</p>
+    <p><small>{{.Title}} will be available in an upcoming PR.</small></p>
+</div>
+{{end}}

--- a/web/templates/pages/register.html
+++ b/web/templates/pages/register.html
@@ -1,0 +1,61 @@
+{{define "content"}}
+<div class="auth-page" x-data="{ name: '', email: '', password: '' }">
+    <div class="auth-card">
+        <h2>Create your account</h2>
+        <p class="auth-subtitle">Start tracking your finances</p>
+
+        {{if .Flashes}}
+        <div class="flashes">
+            {{range .Flashes}}
+            <article class="flash flash-{{.Type}}">{{.Message}}</article>
+            {{end}}
+        </div>
+        {{end}}
+
+        <form hx-post="/register" hx-target="body" hx-push-url="false" method="POST">
+            <label>
+                Name
+                <input type="text" name="name" x-model="name" required autofocus 
+                       placeholder="Your name">
+            </label>
+            <label>
+                Email
+                <input type="email" name="email" x-model="email" required 
+                       placeholder="you@example.com" autocomplete="email">
+            </label>
+            <label>
+                Password
+                <input type="password" name="password" x-model="password" required 
+                       placeholder="Min 6 characters" minlength="6" autocomplete="new-password">
+            </label>
+            <button type="submit" class="w-full">Create account</button>
+        </form>
+
+        <p class="auth-footer">
+            Already have an account? <a href="/login">Sign in</a>
+        </p>
+    </div>
+</div>
+
+<style>
+.auth-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: calc(100vh - 4rem);
+    margin: 0;
+}
+.auth-card {
+    width: 100%;
+    max-width: 400px;
+    background: var(--pico-card-background-color);
+    border: 1px solid var(--pico-card-border-color);
+    border-radius: 12px;
+    padding: 2rem;
+}
+.auth-card h2 { margin: 0 0 0.25rem; }
+.auth-subtitle { color: var(--pico-muted-color); margin-bottom: 1.5rem; font-size: 0.95rem; }
+.auth-footer { text-align: center; margin-top: 1.5rem; font-size: 0.9rem; color: var(--pico-muted-color); }
+.w-full { width: 100%; }
+</style>
+{{end}}

--- a/web/templates/partials/nav.html
+++ b/web/templates/partials/nav.html
@@ -1,0 +1,60 @@
+{{define "nav.html"}}
+<nav class="sidebar" x-data="{ mobileOpen: false }">
+    <div class="sidebar-brand">
+        <a href="/dashboard" class="brand-link">
+            <span class="brand-icon">📒</span>
+            <span class="brand-name">Ledgerify</span>
+        </a>
+    </div>
+
+    <button class="mobile-toggle" @click="mobileOpen = !mobileOpen" aria-label="Toggle menu">
+        <span x-show="!mobileOpen">☰</span>
+        <span x-show="mobileOpen">✕</span>
+    </button>
+
+    <div class="sidebar-links" x-bind:class="mobileOpen ? 'open' : ''">
+        <a href="/dashboard" class="nav-link{{if eqStr .CurrentPath "/dashboard"}} active{{end}}">
+            <span class="nav-icon">🏠</span> Dashboard
+        </a>
+        <a href="/transactions" class="nav-link{{if hasPrefix .CurrentPath "/transactions"}} active{{end}}">
+            <span class="nav-icon">💳</span> Transactions
+        </a>
+        <a href="/accounts" class="nav-link{{if hasPrefix .CurrentPath "/accounts"}} active{{end}}">
+            <span class="nav-icon">🏦</span> Accounts
+        </a>
+        <a href="/budgets" class="nav-link{{if hasPrefix .CurrentPath "/budgets"}} active{{end}}">
+            <span class="nav-icon">📊</span> Budgets
+        </a>
+        <a href="/investments" class="nav-link{{if hasPrefix .CurrentPath "/investments"}} active{{end}}">
+            <span class="nav-icon">📈</span> Investments
+        </a>
+        <a href="/loans" class="nav-link{{if hasPrefix .CurrentPath "/loans"}} active{{end}}">
+            <span class="nav-icon">💰</span> Loans
+        </a>
+        <a href="/insurance" class="nav-link{{if hasPrefix .CurrentPath "/insurance"}} active{{end}}">
+            <span class="nav-icon">🛡️</span> Insurance
+        </a>
+        <a href="/networth" class="nav-link{{if hasPrefix .CurrentPath "/networth"}} active{{end}}">
+            <span class="nav-icon">💎</span> Net Worth
+        </a>
+
+        <hr class="nav-divider">
+
+        <a href="/reports" class="nav-link{{if hasPrefix .CurrentPath "/reports"}} active{{end}}">
+            <span class="nav-icon">📋</span> Reports
+        </a>
+        <a href="/import" class="nav-link{{if hasPrefix .CurrentPath "/import"}} active{{end}}">
+            <span class="nav-icon">📥</span> Import
+        </a>
+
+        <hr class="nav-divider">
+
+        <a href="/settings" class="nav-link{{if hasPrefix .CurrentPath "/settings"}} active{{end}}">
+            <span class="nav-icon">⚙️</span> Settings
+        </a>
+        <a href="/logout" class="nav-link nav-logout">
+            <span class="nav-icon">🚪</span> Logout
+        </a>
+    </div>
+</nav>
+{{end}}


### PR DESCRIPTION
## Stacked PR #1 of 8 — htmx Migration

Sets up the core template engine, auth middleware, routing, and base layout. All future PRs build on this.

### What's included
- **Template engine** (`internal/templates/`): cached compilation, partial support, rich template funcs (currency, date, math)
- **Page auth middleware**: JWT via `token` cookie first, `Authorization` header fallback
- **Go embed**: templates + static assets compiled into the binary (via `embedassets` package)
- **Base layout**: Pico.css dark-first, Alpine.js theme toggle (persisted via cookie)
- **Sidebar navigation**: all future module routes pre-registered
- **Custom CSS**: card grids, transaction tables, budget bars, modals, responsive mobile
- **Auth pages**: login + register templates (form + styling, bcrypt + JWT cookie on POST)
- **Routes**: all `/page` and `/api/v1` routes registered in chi router
- **Static serving**: embedded CSS served at `/static/`

### Design decisions
- Coexists alongside existing Next.js frontend — nothing deleted yet
- Templates embedded for single-binary deployment
- Dark-first with light toggle (Pico.css `data-theme`)
- htmx 2.0 for progressive enhancement + Alpine.js for interactivity
- Flash messages via short-lived cookie

### Next PR: Auth pages with full login/register/logout flow
