### PR TITLE
Phase 2: Dashboard page with real summary data

### DIFF
--- a/internal/templates/dashboard.go
+++ b/internal/templates/dashboard.go
@@ -1,0 +1,209 @@
+package templates
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/KTS-o7/ledgerify-web/internal/db"
+	"github.com/KTS-o7/ledgerify-web/internal/middleware"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// DashboardData contains all data for the dashboard page.
+type DashboardData struct {
+	TotalIncome        float64
+	TotalExpenses      float64
+	NetAmount          float64
+	TotalBalance       float64
+	Currency           string
+	AccountCount       int
+	RecentTransactions []DashboardTxn
+	BudgetStatus       []DashboardBudget
+	MonthlyNetworth    []DashboardNetworth
+}
+
+// DashboardTxn is a simplified transaction for the dashboard table.
+type DashboardTxn struct {
+	DateFormatted string
+	Title         string
+	CategoryName  string
+	AccountName   string
+	Amount        float64
+}
+
+// DashboardBudget is a budget status for the dashboard.
+type DashboardBudget struct {
+	Name      string
+	Amount    float64
+	Spent     float64
+	Remaining float64
+	SpentPct  float64
+	Currency  string
+}
+
+// DashboardNetworth is a monthly net worth data point.
+type DashboardNetworth struct {
+	MonthLabel string
+	Networth   float64
+}
+
+// DashboardPage renders the dashboard with real data.
+func (ph *PageHandlers) DashboardPage(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.GetUserClaims(r)
+	if claims == nil {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	data := NewPageData(r, "Dashboard")
+	dd := ph.fetchDashboardData(r.Context(), claims.UserID)
+	data.Data = dd
+	RenderPage(w, "dashboard", data)
+}
+
+func (ph *PageHandlers) fetchDashboardData(ctx context.Context, userID string) DashboardData {
+	userUUID := pgtype.UUID{Bytes: uuid.MustParse(userID), Valid: true}
+	now := time.Now()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	monthEnd := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, now.Location()).Add(-time.Nanosecond)
+
+	dd := DashboardData{
+		Currency: "USD",
+	}
+
+	// Fetch in parallel where possible
+	// Total income/expenses
+	dd.TotalIncome, dd.TotalExpenses = computeMonthlyTotals(ctx, ph.pool, userUUID, monthStart, monthEnd)
+	dd.NetAmount = math.Round((dd.TotalIncome-dd.TotalExpenses)*100) / 100
+
+	// Account balances
+	accounts, err := ph.cq.ListAccountsWithBalance(ctx, userID)
+	if err == nil {
+		for _, a := range accounts {
+			dd.TotalBalance += a.Balance
+		}
+		dd.AccountCount = len(accounts)
+		// Get user's default currency
+		if len(accounts) > 0 && accounts[0].Currency != "" {
+			dd.Currency = accounts[0].Currency
+		}
+	}
+	dd.TotalBalance = math.Round(dd.TotalBalance*100) / 100
+
+	// Recent transactions (last 5)
+	limitRows := pgtype.Int4{Int32: 5, Valid: true}
+	txns, err := ph.q.ListTransactionsByUser(ctx, db.ListTransactionsByUserParams{
+		UserID:    userUUID,
+		LimitRows: limitRows,
+	})
+	if err == nil {
+		for _, t := range txns {
+			amt, _ := t.Amount.Float64Value()
+			amount := 0.0
+			if amt.Valid {
+				amount = amt.Float64
+			}
+
+			catName := ""
+			if t.CategoryName.Valid {
+				catName = t.CategoryName.String
+			}
+
+			title := ""
+			if t.Title.Valid {
+				title = t.Title.String
+			}
+
+			dateFormatted := ""
+			if t.Date.Valid {
+				dateFormatted = t.Date.Time.Format("Jan 2")
+			}
+
+			dd.RecentTransactions = append(dd.RecentTransactions, DashboardTxn{
+				DateFormatted: dateFormatted,
+				Title:         title,
+				CategoryName:  catName,
+				AccountName:   t.AccountName,
+				Amount:        amount,
+			})
+		}
+	}
+
+	// Budget status
+	budgets, err := ph.q.ListBudgetsByUser(ctx, userUUID)
+	if err == nil {
+		for _, b := range budgets {
+			amt, _ := b.Amount.Float64Value()
+			amount := 0.0
+			if amt.Valid {
+				amount = amt.Float64
+			}
+
+			var spent float64
+			if b.CategoryID.Valid {
+				_ = ph.pool.QueryRow(ctx,
+					`SELECT COALESCE(SUM(t.amount), 0)::numeric(18,4)
+					FROM transactions t
+					WHERE t.user_id = $1 AND t.type = 'expense'
+					  AND t.category_id = $2
+					  AND t.date >= $3 AND t.date <= $4
+					  AND t.deleted_at IS NULL`,
+					userUUID, b.CategoryID, monthStart, monthEnd,
+				).Scan(&spent)
+			}
+
+			remaining := amount - spent
+			spentPct := 0.0
+			if amount > 0 {
+				spentPct = math.Round((spent / amount) * 100)
+			}
+
+			dd.BudgetStatus = append(dd.BudgetStatus, DashboardBudget{
+				Name:      b.Name,
+				Amount:    math.Round(amount*100) / 100,
+				Spent:     math.Round(spent*100) / 100,
+				Remaining: math.Round(remaining*100) / 100,
+				SpentPct:  spentPct,
+				Currency:  b.Currency,
+			})
+		}
+	}
+
+	// Monthly net worth
+	sixMonthsAgo := monthStart.AddDate(0, -5, 0)
+	nw, err := ph.cq.GetMonthlyNetworth(ctx, userID, sixMonthsAgo, monthEnd)
+	if err == nil {
+		for _, row := range nw {
+			// Parse date and format month label
+			t, err := time.Parse("2006-01-02", row.Date)
+			label := row.Date
+			if err == nil {
+				label = t.Format("Jan")
+			}
+			dd.MonthlyNetworth = append(dd.MonthlyNetworth, DashboardNetworth{
+				MonthLabel: label,
+				Networth:   math.Round(row.TotalBalance*100) / 100,
+			})
+		}
+	}
+
+	return dd
+}
+
+// computeMonthlyTotals calculates total income and expenses for a date range.
+func computeMonthlyTotals(ctx context.Context, pool *pgxpool.Pool, userUUID pgtype.UUID, monthStart, monthEnd time.Time) (income, expenses float64) {
+	_ = pool.QueryRow(ctx,
+		`SELECT
+			COALESCE(SUM(CASE WHEN type = 'income' THEN amount ELSE 0 END), 0)::numeric(18,4),
+			COALESCE(SUM(CASE WHEN type = 'expense' THEN amount ELSE 0 END), 0)::numeric(18,4)
+		FROM transactions
+		WHERE user_id = $1 AND deleted_at IS NULL
+		  AND date >= $2 AND date <= $3`,
+		userUUID, monthStart, monthEnd,
+	).Scan(&income, &expenses)
+	return
+}

--- a/internal/templates/dashboard.go
+++ b/internal/templates/dashboard.go
@@ -143,6 +143,9 @@ func (ph *PageHandlers) fetchDashboardData(ctx context.Context, userID string) D
 				amount = amt.Float64
 			}
 
+			// Compute the current spending window for this budget's period.
+			bStart, bEnd := budgetSpendingWindow(b, now)
+
 			var spent float64
 			if b.CategoryID.Valid {
 				_ = ph.pool.QueryRow(ctx,
@@ -152,7 +155,7 @@ func (ph *PageHandlers) fetchDashboardData(ctx context.Context, userID string) D
 					  AND t.category_id = $2
 					  AND t.date >= $3 AND t.date <= $4
 					  AND t.deleted_at IS NULL`,
-					userUUID, b.CategoryID, monthStart, monthEnd,
+					userUUID, b.CategoryID, bStart, bEnd,
 				).Scan(&spent)
 			}
 
@@ -206,4 +209,44 @@ func computeMonthlyTotals(ctx context.Context, pool *pgxpool.Pool, userUUID pgty
 		userUUID, monthStart, monthEnd,
 	).Scan(&income, &expenses)
 	return
+}
+
+// budgetSpendingWindow returns the start/end dates for a budget's current spending period.
+func budgetSpendingWindow(b db.ListBudgetsByUserRow, now time.Time) (time.Time, time.Time) {
+	loc := now.Location()
+
+	switch b.PeriodType {
+	case "weekly":
+		weekday := now.Weekday()
+		if weekday == time.Sunday {
+			weekday = 7
+		}
+		start := now.AddDate(0, 0, -int(weekday-time.Monday))
+		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, loc)
+		end := start.AddDate(0, 0, 6)
+		end = time.Date(end.Year(), end.Month(), end.Day(), 23, 59, 59, 999999999, loc)
+		return start, end
+
+	case "yearly":
+		start := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, loc)
+		end := time.Date(now.Year(), 12, 31, 23, 59, 59, 999999999, loc)
+		return start, end
+
+	case "custom", "one_time":
+		start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, loc)
+		end := start.AddDate(0, 1, 0).Add(-time.Nanosecond)
+		if b.StartDate.Valid {
+			start = b.StartDate.Time
+		}
+		if b.EndDate.Valid {
+			end = b.EndDate.Time
+			end = time.Date(end.Year(), end.Month(), end.Day(), 23, 59, 59, 999999999, loc)
+		}
+		return start, end
+
+	default: // "monthly" or unknown
+		start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, loc)
+		end := start.AddDate(0, 1, 0).Add(-time.Nanosecond)
+		return start, end
+	}
 }

--- a/internal/templates/handlers.go
+++ b/internal/templates/handlers.go
@@ -154,12 +154,6 @@ func (ph *PageHandlers) RegisterAction(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
 }
 
-// DashboardPage renders the dashboard.
-func (ph *PageHandlers) DashboardPage(w http.ResponseWriter, r *http.Request) {
-	data := NewPageData(r, "Dashboard")
-	RenderPage(w, "placeholder", data)
-}
-
 // Placeholder returns a handler that renders the placeholder page.
 func (ph *PageHandlers) Placeholder(title string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -1,0 +1,137 @@
+{{define "content"}}
+
+<!-- Summary Cards -->
+<div class="card-grid">
+    <div class="dashboard-card">
+        <div class="card-label">Income (this month)</div>
+        <div class="card-value positive">{{formatCurrency .Data.TotalIncome .Data.Currency}}</div>
+    </div>
+    <div class="dashboard-card">
+        <div class="card-label">Expenses (this month)</div>
+        <div class="card-value negative">{{formatCurrency .Data.TotalExpenses .Data.Currency}}</div>
+    </div>
+    <div class="dashboard-card">
+        <div class="card-label">Net (this month)</div>
+        <div class="card-value {{amountClass .Data.NetAmount}}">{{formatAmount .Data.NetAmount .Data.Currency}}</div>
+    </div>
+    <div class="dashboard-card">
+        <div class="card-label">Total Balance</div>
+        <div class="card-value">{{formatCurrency .Data.TotalBalance .Data.Currency}}</div>
+        <div class="card-sub">{{.Data.AccountCount}} accounts</div>
+    </div>
+</div>
+
+<!-- Recent Transactions -->
+<h2 class="section-title">Recent Transactions</h2>
+{{if .Data.RecentTransactions}}
+<div style="overflow-x:auto;">
+    <table class="txn-table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Title</th>
+                <th>Category</th>
+                <th>Account</th>
+                <th>Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{range .Data.RecentTransactions}}
+            <tr class="txn-row">
+                <td>{{.DateFormatted}}</td>
+                <td>{{.Title}}</td>
+                <td>{{.CategoryName}}</td>
+                <td>{{.AccountName}}</td>
+                <td class="{{amountClass .Amount}}">{{formatCurrency .Amount $.Data.Currency}}</td>
+            </tr>
+        {{end}}
+        </tbody>
+    </table>
+</div>
+<p style="margin-top:.5rem;text-align:right;">
+    <a href="/transactions" class="small">View all transactions →</a>
+</p>
+{{else}}
+<div class="empty-state">
+    <div class="empty-icon">💳</div>
+    <p>No transactions yet</p>
+    <a href="/transactions" role="button" class="outline">Add your first transaction</a>
+</div>
+{{end}}
+
+<!-- Budget Status -->
+{{if .Data.BudgetStatus}}
+<h2 class="section-title">Budget Status</h2>
+<div class="card-grid">
+{{range .Data.BudgetStatus}}
+    <div class="dashboard-card">
+        <div class="card-label">{{.Name}}</div>
+        <div class="card-value">{{formatCurrency .Spent $.Data.Currency}} <small>of {{formatCurrency .Amount $.Data.Currency}}</small></div>
+        <div class="budget-bar">
+            <div class="budget-bar-fill {{ternary (lt .SpentPct 70) "safe" (ternary (lt .SpentPct 90) "warning" "danger")}}" 
+                 style="width:{{.SpentPct}}%"></div>
+        </div>
+        <div class="card-sub">{{formatPercent .SpentPct}} spent · {{formatCurrency .Remaining $.Data.Currency}} remaining</div>
+    </div>
+{{end}}
+</div>
+{{end}}
+
+<!-- Net Worth Chart Placeholder -->
+<h2 class="section-title">Net Worth Trend</h2>
+<div class="chart-container">
+    <canvas id="networth-chart" height="200"></canvas>
+</div>
+
+<script>
+    // Net worth chart (simple canvas)
+    (function() {
+        const canvas = document.getElementById('networth-chart');
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        canvas.width = canvas.parentElement.clientWidth;
+        
+        const data = [
+            {{range .Data.MonthlyNetworth}}
+            {month: "{{.MonthLabel}}", value: {{.Networth}} },
+            {{end}}
+        ];
+        if (data.length < 2) {
+            ctx.fillStyle = 'var(--pico-muted-color)';
+            ctx.fillText('Not enough data yet', 10, 30);
+            return;
+        }
+
+        // Draw chart (simple hardcoded chart until Chart.js in Phase 6)
+        const w = canvas.width - 40;
+        const h = canvas.height - 40;
+        const max = Math.max(...data.map(d => d.value));
+        const min = Math.min(...data.map(d => d.value), 0);
+        const range = max - min || 1;
+        
+        ctx.strokeStyle = '#6c63ff';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        
+        data.forEach((d, i) => {
+            const x = 20 + (i / (data.length - 1)) * w;
+            const y = h - ((d.value - min) / range) * h + 20;
+            if (i === 0) ctx.moveTo(x, y);
+            else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+        
+        // Labels
+        ctx.fillStyle = 'var(--pico-muted-color)';
+        ctx.font = '11px sans-serif';
+        data.forEach((d, i) => {
+            const x = 20 + (i / (data.length - 1)) * w;
+            ctx.fillText(d.month, x - 15, h + 35);
+        });
+    })();
+</script>
+
+<style>
+.small { font-size: .85rem; }
+</style>
+{{end}}


### PR DESCRIPTION
## Stacked PR #2 of 8 — Dashboard

**Base:** `feat/htmx-foundation` (#31)

Replaces the placeholder dashboard with a live data-driven page.

### What's included
- **DashboardData struct**: income, expenses, net, total balance, currency, account count
- **fetchDashboardData**: queries summary, accounts, transactions, budgets, monthly net worth
- **Dashboard template**: 
  - 4 summary cards (income, expenses, net, total balance)
  - Recent 5 transactions table with date/title/category/account/amount
  - Budget status bars with color-coded fill (safe/warning/danger based on %)
  - Net worth trend chart (simple canvas chart until Chart.js in Phase 6)
- **computeMonthlyTotals**: direct SQL for current month income/expenses
- Removes DashboardPage placeholder stub

### Design
- All data-fetching in `dashboard.go` (separate file, clean separation)
- Empty states for no transactions, no budgets, insufficient net worth data
- Responsive card grid (2-4 columns based on screen width)
- Budget bars animate to fill percentage via inline style width

### Next PR: Transactions — list, create, filter, search
