### PR TITLE
feat: terracotta UI refresh - warm minimal design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ vendor/
 
 # Server config (sensitive - manage outside repo)
 /nginx/
+.superpowers/

--- a/docs/superpowers/specs/2026-05-18-terracotta-ui-refinement-design.md
+++ b/docs/superpowers/specs/2026-05-18-terracotta-ui-refinement-design.md
@@ -1,0 +1,307 @@
+# Design Spec: Ledgerify UI Refinement — Terracotta
+
+**Date:** 2026-05-18
+**Status:** Approved for implementation planning
+
+## Overview
+
+Stripped the previous Graphite + Lime design. Replaced with a warm, minimal aesthetic inspired by Apple and Notion — terracotta accent, warm neutrals, compact sidebar, borders over shadows, typography-driven hierarchy.
+
+## Constraints
+
+- Same stack: Go + HTMX + Pico.css (v2) + Alpine (minimal)
+- No new frontend frameworks, icon libraries, external fonts, image assets, or build steps
+- Chart.js scoped to report pages only; dashboard uses inline SVG/CSS charts (zero dependencies)
+- Default theme: light; dark mode toggle via `data-theme` attribute
+- Verification: `go test ./...`, `go build`, `git diff --check`
+
+## Design Principles
+
+| Principle | Description |
+|---|---|
+| Typography-driven | Size/weight/color create hierarchy, not boxes |
+| Minimal chrome | No card containers wrapping everything |
+| Borders over shadows | 1px borders, no drop shadows |
+| Terracotta as precise accent | Used sparingly — active nav, primary buttons, links |
+| Warm neutrals | Cream undertones, no cool grays |
+| Apple/Notion precision | Thin borders, generous whitespace, intentional spacing |
+
+## Color System
+
+### Light Mode
+
+| Token | Hex | Usage |
+|---|---|---|
+| Canvas | `#f8f7f5` | Page background |
+| Surface | `#ffffff` | Tables, forms, charts |
+| Surface muted | `#f0eeec` | Badges, subtle fills |
+| Text | `#1a1816` | Body text |
+| Text muted | `#7a7570` | Labels, secondary |
+| Line | `#e8e5e2` | Borders (strong) |
+| Line faint | `#f0eeec` | Row separators (subtle) |
+| Accent | `#c25a3e` | Primary buttons, active nav, links |
+| Accent hover | `#a34730` | Button hover |
+| Accent muted | `rgba(194,90,62,0.08)` | Hover fills, chart area |
+| Income | `#16835a` | Green amounts |
+| Expense | `#bd3e3e` | Red amounts |
+| Warning | `#b7791f` | Amber alerts |
+
+### Dark Mode
+
+| Token | Hex | Usage |
+|---|---|---|
+| Canvas | `#14100e` | Page background |
+| Surface | `#0f0c0a` | Tables, forms, charts |
+| Surface muted | `#1f1a17` | Badges, subtle fills |
+| Text | `#ece3dc` | Body text (warm white) |
+| Text muted | `#7a6b63` / `#9a8b82` | Labels, secondary |
+| Line | `#1f1a17` | Borders |
+| Accent | `#d07a5f` | Buttons, active nav, links (lighter for dark bg) |
+| Accent hover | `#e08a6f` | Button hover |
+| Accent muted | `rgba(208,122,95,0.12)` | Hover fills, chart area |
+
+### Semantic colors (unchanged across themes)
+- Positive: `#16835a`
+- Negative: `#bd3e3e`
+- Warning: `#b7791f`
+- Info: `#2563eb`
+
+## Layout
+
+### Desktop (>768px)
+```
+┌────┬─────────────────────────────────┐
+│    │  Page title            [theme]  │
+│ 52 │                                 │
+│ px │  Net worth (hero number)        │
+│    │                                 │
+│ s  │  Income | Expenses | Cash Flow  │
+│ i  │  (thin dividers, no cards)      │
+│ d  │                                 │
+│ e  │  ┌─Transactions──┐ ┌─Budgets──┐ │
+│ b  │  │ dot + row     │ │ progress │ │
+│ a  │  │ dot + row     │ │ progress │ │
+│ r  │  └───────────────┘ └──────────┘ │
+│    │  ┌─Net Worth Chart─────────────┐│
+│    │  │ SVG line chart              ││
+│    │  └─────────────────────────────┘│
+└────┴─────────────────────────────────┘
+```
+
+- **Sidebar:** 52px wide, warm dark (`#1a1816` light, `#0f0c0a` dark), inline SVG icons, terracotta active state with left indicator bar
+- **Content area:** Max ~1080px, padded, warm cream canvas
+- **Borders:** 1px `#e8e5e2` (up from 0.5px — real CSS can't do sub-pixel reliably)
+
+### Mobile (<768px)
+- Sidebar collapses to bottom tab bar (5 primary nav items, icon + 9px label)
+- Content fills full width
+- KPI row stacks vertically at <620px
+- Tables become stacked card rows
+
+### Breakpoints
+| Breakpoint | Behavior |
+|---|---|
+| >768px | Full sidebar, multi-column layout |
+| 620-768px | Bottom tab nav, 2-col grid becomes 1-col |
+| <620px | Single column, stacked KPIs, stacked table rows |
+
+## Typography
+
+System font stack (unchanged — performant):
+```
+ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+"Segoe UI", Roboto, sans-serif
+```
+
+| Element | Size | Weight | Notes |
+|---|---|---|---|
+| Hero number | 38-40px | 550 | Tight letter-spacing |
+| Page title | 22-24px | 500 | Apple medium weight |
+| KPI value | 16-17px | 500 | Not too large |
+| Body text | 13-14px | 400 | Table rows, descriptions |
+| Section title | 12-13px | 500 | Compact headers |
+| Label | 11px | 500 | Uppercase, 0.5px letter-spacing |
+| Badge | 11px | 400 | Tinted background |
+| Table header | 11px | 500 | Uppercase, 0.3px letter-spacing |
+
+## Navigation
+
+### Compact Sidebar (52px)
+- Inline SVG icons (hand-coded, ~12-15 paths, ~150-200 bytes each)
+- Active state: terracotta icon + 3px left indicator bar
+- Default state: muted warm gray (`#7a7570` light, `#5a524d` dark)
+- Brand mark: "L" letter logo in terracotta fill
+- Bottom: settings gear icon in bordered circle
+- Tooltip labels on hover (desktop only)
+
+### Icons needed
+- Dashboard (grid)
+- Transactions (list lines)
+- Accounts (building/columns)
+- Budgets (chart bars)
+- Reports (chart line)
+- Settings (gear)
+- Theme toggle (sun/moon)
+
+## Components
+
+### Buttons
+| Variant | Style |
+|---|---|
+| Primary | Terracotta fill, white text, 1px inner top highlight (`rgba(255,255,255,0.15)`), 7px radius |
+| Secondary | 1px `#d4d0cb` border, white fill, `#1a1816` text, 7px radius |
+| Ghost | Terracotta text only |
+| Small/icon | 1px border, 6px radius, icon + optional text |
+| Active filter | Terracotta fill, white text |
+| Inactive filter | White fill, 1px border, `#1a1816` text |
+
+### Forms
+- Labels: 11px, 500 weight, `#7a7570`, 0.3px letter-spacing
+- Input wrapper: 1px `#d4d0cb`, 8px radius, 9px padding, white fill, subtle inset shadow
+- Focus state: 2px terracotta ring
+- Inline decorations: `$` prefix, `USD` badge, chevron for selects, calendar icon for dates
+- Placeholder: `#7a7570`
+
+### Badges / Category Pills
+- Background: `#f0eeec` (light), `#1f1a17` (dark)
+- 5px radius, 2-3px padding top/bottom, 7-10px horizontal
+- Colored dot (5px, 50% radius) before text — each category gets its own color
+- Active/emphasis: terracotta fill, white text, no dot
+
+### Progress Bars
+- 3px height, `#f0eeec` track (light), `#1f1a17` track (dark)
+- Terracotta fill, 2px radius
+- Label above: category name left, amount/percentage right
+
+### Tables
+- Bordered container (1px `#e8e5e2`, 8px radius)
+- Uppercase header row, 11px, `#7a7570`, border-bottom separator
+- Data rows: 13px, `#1a1816` text, `#f0eeec` row separator
+- Hover: `rgba(194,90,62,0.03)` tint on row
+- Action menu: `⋯` icon in 28px bordered circle on last column
+
+### Filter Chips (segmented control)
+- Active: terracotta fill, white text, 6px radius
+- Inactive: white fill, 1px `#d4d0cb` border, `#1a1816` text
+- 5px padding vertical, 12px horizontal, 12px text
+
+### Empty State
+- Dashed border container (1px `#d4d0cb`, 8px radius)
+- Centered muted icon (28px), description text, terracotta CTA button
+
+### Toggle / Theme Switch
+- In header: pill-style with "Light" / "Dark" labels, active state highlighted
+- Border: 1px `#d4d0cb`, 6px radius, 4px padding
+
+## Charts
+
+### Monthly Spending Heatmap
+- Pure CSS grid of 12px × 12px cells, 2px radius, 2px gap
+- 7 rows (days of week) × ~52 columns (weeks)
+- Intensity levels via CSS classes:
+  - `.level-0`: `#f0eeec` (no spending)
+  - `.level-1`: `#ffe4dd` (low)
+  - `.level-2`: `rgba(194,90,62,0.2)` (medium)
+  - `.level-3`: `rgba(194,90,62,0.4)` (high)
+  - `.level-4`: `#c25a3e` (very high)
+  - `.level-5`: `#8a3a2a` (extreme)
+- Legend bar at bottom: Less → More with sample cells
+- Zero JavaScript. Server-renders cells based on daily totals.
+
+### Net Worth Line Chart (Dashboard)
+- Inline SVG `<path>` with `fill="none"` stroke + area fill
+- `<polyline>` or `<path>` rendered server-side from data points
+- Grid lines: 4 horizontal, light line color
+- Y-axis labels (3-4), X-axis labels (months)
+- Latest data point: 3px terracotta dot + 5px halo
+- Period selector (1M / 3M / 1Y / All) — filter chips above chart
+
+### Category Donut (Dashboard overview)
+- Inline SVG `<circle>` segments with `stroke-dasharray`
+- Segments: housing (terracotta), food (blue), transport (green), utilities (amber)
+- Legend to the right: colored square + name + amount
+
+### Interactive Charts (Report Pages)
+- Chart.js loaded via `<script src>` inside `{{if .Data}}` block — never on non-report pages
+- Bar charts (income vs expense), line charts (trends), doughnut (category breakdown)
+- Same color palette mapped to Chart.js config
+
+## Page Layouts
+
+### Dashboard
+- Page title + theme toggle in header
+- Net worth hero (38-40px number + trend)
+- KPI strip: Income | Expenses | Cash Flow | Savings Rate (thin vertical dividers, no cards)
+- Two-column grid: Recent Transactions (left, 1.4fr) | Budgets (right, 1fr)
+- Below: Net Worth Trend SVG chart
+
+### Transactions
+- Page title + "Add" primary button
+- Filter chip row: All | Income | Expenses | This Month + search input with icon
+- Full table with action menu (⋯) on each row
+- Pagination below table
+
+### Budgets
+- Page title + "Set Budget" button
+- 2-column grid of budget cards
+- Each card: category name, spent amount, total budget, progress bar
+- Color-coded progress: green if <60%, amber if 60-85%, terracotta if >85%
+
+### Settings
+- Page title
+- 3-column tile grid
+- Each tile: 1px border, 8px radius, title + description
+- No icons on tiles (keeps it clean)
+
+### Accounts / Investments / Loans / Insurance
+- Consistent list page pattern: page title + CTA, filter/search bar, table with rows
+- Same table component, same badge style
+
+### Reports
+- Index page: tile grid matching settings pattern
+- Report pages: Chart.js charts inside bordered container, period filter chips
+
+## Dark Mode Implementation
+
+- Toggle via `data-theme="dark"` on `<html>`, persisted to localStorage
+- All colors use CSS custom properties, swapped via `[data-theme="dark"]` selector
+- Pico.css default theme variables overridden for both light and dark
+- No `prefers-color-scheme` media query (user controls toggle)
+- Same layout and component structure; only colors invert
+
+## Responsive Behavior
+
+| Element | >768px | 620-768px | <620px |
+|---|---|---|---|
+| Sidebar | 52px rail | Bottom tab bar | Bottom tab bar |
+| KPI row | Horizontal, dividers | 2×2 grid | Stacked vertical |
+| Dashboard grid | 2 columns | 1 column | 1 column |
+| Budgets grid | 2 columns | 2 columns | 1 column |
+| Settings grid | 3 columns | 2 columns | 1 column |
+| Tables | Full table | Full table (scroll) | Stacked cards |
+| Charts | Full width | Full width | Hidden / stacked |
+
+## Sidebar Icons (Inline SVG)
+
+The following icons are hand-coded as inline SVG `<svg>` elements in `base.html`, served as part of the template (no external HTTP requests):
+
+| Nav item | Icon shape | SVG path description |
+|---|---|---|
+| Dashboard | 2×2 grid of small squares | 4 `<rect>` elements |
+| Transactions | Horizontal lines | 3 `<line>` or `<path>` lines |
+| Accounts | Bank/building | `<rect>` + `<path>` columns |
+| Budgets | Bar chart | 3 `<rect>` bars at different heights |
+| Reports | Chart line | `<path>` with up-trend |
+| Settings | Gear/cog | `<circle>` + 6 spokes `<path>`s (sun icon pattern) |
+| Theme | Sun/moon | Sun rays or moon crescent |
+
+Each icon is ~150-200 bytes, rendered inline, no HTTP overhead.
+
+## Implementation Notes
+
+- **CSS organization:** Custom CSS continues in `web/static/css/custom.css`. Organize by: custom properties (colors), layout, navigation, components, charts, responsive, dark mode.
+- **Pico.css overrides:** Reduce `!important` usage by targeting `[data-theme]` selectors with higher specificity.
+- **SVG charts:** Data is passed from Go handlers as JSON or pre-computed path strings. Templates render SVG directly — no JS charting on dashboard.
+- **Heatmap:** Handler computes daily totals, passes to template. Template iterates days and assigns CSS level classes.
+- **Chart.js remains** on report pages only, loaded conditionally inside `{{if .Data}}` blocks.
+- **No icon library** — all icons are inline SVG snippets in the nav partial.

--- a/web/static/css/custom.css
+++ b/web/static/css/custom.css
@@ -1,907 +1,1565 @@
-/* ============================================
-   Ledgerify — Graphite + Lime UI Refresh
-   Lightweight finance console on top of Pico.css
-   ============================================ */
+/* =============================================
+   Ledgerify — Terracotta UI Refinement
+   Warm minimal aesthetic on Pico.css v2
+   ============================================= */
 
-/* === CSS Tokens === */
+/* === 1. Custom Properties === */
+
 :root {
-    --sidebar-width: 76px;
-    --sidebar-expanded-width: 232px;
-    --header-height: 64px;
-    --radius: 8px;
-    --radius-sm: 6px;
-    --canvas: #f7f8f5;
-    --surface: #ffffff;
-    --surface-muted: #eef3ec;
-    --graphite: #17241e;
-    --graphite-2: #22322a;
-    --graphite-3: #30443a;
-    --lime: #d7ff67;
-    --lime-strong: #bff03f;
-    --line: #dfe5dc;
-    --line-strong: #cbd6ca;
-    --text: #111814;
-    --text-muted: #66736a;
-    --positive: #16835a;
-    --negative: #bd3e3e;
-    --warning: #b7791f;
-    --info: #2563eb;
-    --shadow-soft: 0 10px 30px rgba(23, 36, 30, .08);
-    --pico-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --pico-border-radius: var(--radius);
-    --pico-primary: var(--graphite);
-    --pico-primary-background: var(--graphite);
-    --pico-primary-border: var(--graphite);
-    --pico-primary-hover-background: var(--graphite-2);
-    --pico-primary-hover-border: var(--graphite-2);
+  --canvas: #f8f7f5;
+  --surface: #ffffff;
+  --surface-muted: #f0eeec;
+  --text: #1a1816;
+  --text-muted: #7a7570;
+  --line: #e8e5e2;
+  --line-faint: #f0eeec;
+  --accent: #c25a3e;
+  --accent-hover: #a34730;
+  --accent-muted: rgba(194,90,62,0.08);
+  --positive: #16835a;
+  --negative: #bd3e3e;
+  --warning: #b7791f;
+  --info: #2563eb;
+  --border-color: #d4d0cb;
+  --sidebar-bg: #1a1816;
+  --sidebar-text: #ece3dc;
+  --sidebar-muted: #7a7570;
+  --sidebar-active: #c25a3e;
+
+  --pico-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --pico-border-radius: 7px;
+  --pico-primary: var(--accent);
+  --pico-primary-background: var(--accent);
+  --pico-primary-border: var(--accent);
+  --pico-primary-hover: var(--accent-hover);
+  --pico-primary-hover-background: var(--accent-hover);
+  --pico-primary-hover-border: var(--accent-hover);
+  --pico-primary-focus: var(--accent-muted);
+  --pico-primary-inverse: #fff;
+  --pico-background-color: var(--canvas);
+  --pico-color: var(--text);
+  --pico-muted-color: var(--text-muted);
+  --pico-muted-border-color: var(--line);
+  --pico-form-element-background-color: var(--surface);
+  --pico-form-element-border-color: var(--border-color);
+  --pico-form-element-color: var(--text);
+  --pico-form-element-placeholder-color: var(--text-muted);
+  --pico-form-element-focus-border-color: var(--accent);
+  --pico-form-element-focus-box-shadow: 0 0 0 2px var(--accent-muted);
+  --pico-form-element-spacing-vertical: 9px;
+  --pico-form-element-spacing-horizontal: 12px;
+  --pico-table-border-color: var(--line);
+  --pico-table-row-stripped-background-color: var(--line-faint);
+  --pico-ins-color: var(--positive);
+  --pico-del-color: var(--negative);
+  --pico-mark-background-color: var(--accent-muted);
+  --pico-code-background-color: var(--surface-muted);
 }
 
 [data-theme="dark"] {
-    --canvas: #0f1713;
-    --surface: #16211c;
-    --surface-muted: #1f2d26;
-    --line: #2d4036;
-    --line-strong: #40574b;
-    --text: #edf5ee;
-    --text-muted: #aebcb2;
-    --pico-background-color: var(--canvas);
-    --pico-color: var(--text);
-    --pico-card-background-color: var(--surface);
-    --pico-card-border-color: var(--line);
+  --canvas: #14100e;
+  --surface: #0f0c0a;
+  --surface-muted: #1f1a17;
+  --text: #ece3dc;
+  --text-muted: #9a8b82;
+  --line: #1f1a17;
+  --line-faint: #1f1a17;
+  --accent: #d07a5f;
+  --accent-hover: #e08a6f;
+  --accent-muted: rgba(208,122,95,0.12);
+  --border-color: #3a322e;
+  --sidebar-bg: #0f0c0a;
+  --sidebar-text: #ece3dc;
+  --sidebar-muted: #5a524d;
+  --sidebar-active: #d07a5f;
+
+  --pico-primary: var(--accent);
+  --pico-primary-background: var(--accent);
+  --pico-primary-border: var(--accent);
+  --pico-primary-hover: var(--accent-hover);
+  --pico-primary-hover-background: var(--accent-hover);
+  --pico-primary-hover-border: var(--accent-hover);
+  --pico-primary-focus: var(--accent-muted);
+  --pico-background-color: var(--canvas);
+  --pico-color: var(--text);
+  --pico-muted-color: var(--text-muted);
+  --pico-form-element-background-color: var(--surface);
+  --pico-form-element-border-color: var(--border-color);
+  --pico-form-element-color: var(--text);
+  --pico-form-element-placeholder-color: var(--text-muted);
+  --pico-form-element-focus-border-color: var(--accent);
+  --pico-form-element-focus-box-shadow: 0 0 0 2px var(--accent-muted);
+  --pico-table-border-color: var(--line);
+  --pico-table-row-stripped-background-color: var(--surface-muted);
 }
 
-[data-theme="light"] {
-    --pico-background-color: var(--canvas);
-    --pico-color: var(--text);
-    --pico-card-background-color: var(--surface);
-    --pico-card-border-color: var(--line);
+/* === 2. Base Overrides === */
+
+[data-theme] body {
+  background: var(--canvas);
+  color: var(--text);
+  font-size: 14px;
 }
 
-/* === Global Element Polish === */
-* {
-    box-sizing: border-box;
+[data-theme] a {
+  color: var(--accent);
+  text-decoration: none;
 }
 
-html {
-    background: var(--canvas);
+[data-theme] a:hover {
+  color: var(--accent-hover);
 }
 
-body {
-    min-height: 100vh;
-    background: var(--canvas);
-    color: var(--text);
-    font-size: 15px;
+[data-theme] :focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
-a {
-    color: inherit;
+[data-theme] ::selection {
+  background: var(--accent-muted);
+  color: var(--text);
 }
 
-button,
-input,
-select,
-textarea {
-    font: inherit;
-}
+/* === 3. Layout === */
 
-:focus-visible {
-    outline: 3px solid color-mix(in srgb, var(--lime) 70%, transparent);
-    outline-offset: 2px;
-}
-
-/* === Layout === */
 .app-layout {
-    display: grid;
-    grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
-    min-height: 100vh;
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  min-height: 100vh;
 }
 
-/* === Sidebar === */
-.sidebar {
-    position: sticky;
-    top: 0;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    background: var(--graphite);
-    color: #edf5ee;
-    border-right: 1px solid rgba(215, 255, 103, .12);
-    z-index: 100;
-}
-
-.sidebar-top {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: .75rem;
-    padding: 1rem;
-}
-
-.brand-link {
-    display: flex;
-    align-items: center;
-    gap: .75rem;
-    color: inherit !important;
-    text-decoration: none !important;
-    min-width: 0;
-}
-
-.brand-mark {
-    width: 38px;
-    height: 38px;
-    display: grid;
-    place-items: center;
-    flex: 0 0 auto;
-    border-radius: var(--radius);
-    background: var(--lime);
-    color: var(--graphite);
-    font-weight: 850;
-}
-
-.brand-name {
-    font-weight: 780;
-    letter-spacing: 0;
-}
-
-.sidebar-links {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    gap: .25rem;
-    padding: .25rem .75rem 1rem;
-    overflow-y: auto;
-}
-
-.nav-link {
-    display: flex;
-    align-items: center;
-    gap: .75rem;
-    min-height: 40px;
-    padding: .45rem .55rem;
-    border-radius: var(--radius);
-    color: #b8c8bd !important;
-    text-decoration: none !important;
-    font-size: .9rem;
-    font-weight: 620;
-}
-
-.nav-link:hover {
-    background: rgba(255, 255, 255, .06);
-    color: #fff !important;
-}
-
-.nav-link.active {
-    background: var(--lime);
-    color: var(--graphite) !important;
-}
-
-.nav-key {
-    width: 28px;
-    height: 28px;
-    display: grid;
-    place-items: center;
-    flex: 0 0 auto;
-    border-radius: var(--radius-sm);
-    background: rgba(255, 255, 255, .08);
-    font-size: .75rem;
-    font-weight: 800;
-}
-
-.nav-link.active .nav-key {
-    background: rgba(23, 36, 30, .12);
-}
-
-.nav-divider {
-    margin: .6rem .35rem;
-    border-color: rgba(255, 255, 255, .1);
-}
-
-.nav-logout {
-    margin-top: auto;
-}
-
-.mobile-toggle {
-    display: none;
-    border: 1px solid rgba(255, 255, 255, .16);
-    background: rgba(255, 255, 255, .08);
-    color: #edf5ee;
-    border-radius: var(--radius);
-    padding: .45rem .65rem;
-}
-
-/* === Main Content === */
+.content,
 .main-content {
-    min-width: 0;
-    padding: 1.5rem clamp(1rem, 2vw, 2rem) 2.5rem;
-}
-
-.page-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 1.25rem;
-}
-
-.page-kicker {
-    margin: 0 0 .2rem;
-    color: var(--text-muted);
-    font-size: .76rem;
-    font-weight: 760;
-    letter-spacing: .08em;
-    text-transform: uppercase;
-}
-
-.page-header h1 {
-    margin: 0;
-    color: var(--text);
-    font-size: clamp(1.55rem, 3vw, 2.25rem);
-    line-height: 1.05;
+  min-width: 0;
+  padding: 1.5rem 2rem;
+  max-width: 1120px;
 }
 
 .page-content {
-    max-width: 1240px;
+  margin-top: 1.25rem;
+}
+
+/* === 4. Sidebar === */
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--sidebar-bg);
+  z-index: 100;
+  overflow: hidden;
+}
+
+.sidebar-top {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+}
+
+.brand-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: var(--accent);
+  min-width: 0;
+}
+
+.brand-mark {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.brand-name {
+  display: none;
+}
+
+.mobile-toggle {
+  display: none;
+}
+
+.sidebar-links {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 0 8px 12px;
+  overflow-y: auto;
+  width: 100%;
+}
+
+.nav-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  color: var(--sidebar-muted);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.nav-link svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+  stroke: none;
+}
+
+.nav-link:hover {
+  color: var(--sidebar-text);
+  background: rgba(255,255,255,0.06);
+}
+
+.nav-link.active {
+  color: var(--sidebar-active);
+}
+
+.nav-link.active::before {
+  content: '';
+  position: absolute;
+  left: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 18px;
+  background: var(--sidebar-active);
+  border-radius: 0 2px 2px 0;
+}
+
+.nav-key {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.nav-link.active .nav-key {
+  color: var(--sidebar-active);
+}
+
+.nav-link > span:last-child {
+  display: none;
+  position: absolute;
+  left: calc(100% + 8px);
+  white-space: nowrap;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  pointer-events: none;
+  z-index: 200;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+}
+
+.nav-link:hover > span:last-child {
+  display: block;
+}
+
+.nav-divider {
+  width: 24px;
+  margin: 4px auto;
+  border: none;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  flex-shrink: 0;
+}
+
+.nav-logout {
+  margin-top: auto;
+}
+
+/* Sidebar label shown as tooltip */
+.sidebar-label {
+  display: none;
+}
+
+/* === 5. Page Header === */
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.page-header h1,
+.page-title {
+  font-size: clamp(22px, 2.5vw, 24px);
+  font-weight: 500;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.2;
+}
+
+.page-kicker {
+  margin: 0 0 2px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .header-actions {
-    display: flex;
-    align-items: center;
-    gap: .5rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
-.theme-toggle {
-    border: 1px solid var(--line);
-    background: var(--surface);
-    color: var(--text);
-    border-radius: var(--radius);
-    padding: .45rem .7rem;
-    font-size: .85rem;
-    font-weight: 700;
+/* === 6. Typography === */
+
+.hero-number {
+  font-size: clamp(38px, 5vw, 40px);
+  font-weight: 550;
+  color: var(--text);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0;
 }
 
-/* === Cards & Surfaces === */
-.card-grid,
-.metric-grid,
-.tile-grid,
-.report-grid,
-.settings-grid,
-.export-options {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: .9rem;
-    margin-bottom: 1.25rem;
+.hero-section {
+  margin-bottom: 1.25rem;
 }
 
-.dashboard-card,
-.metric-card,
-.panel,
-.report-card,
-.settings-card,
-.export-card,
-.auth-card,
-.chart-container,
-.table-wrapper,
-.add-section,
-.filters-bar,
-.import-box,
-.coming-soon {
-    background: var(--surface);
-    border: 1px solid var(--line);
-    border-radius: var(--radius);
+.hero-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 4px;
 }
 
-.dashboard-card,
-.metric-card,
-.panel,
-.report-card,
-.settings-card,
-.export-card,
-.auth-card,
-.chart-container,
-.table-wrapper,
-.add-section,
-.filters-bar,
-.import-box,
-.coming-soon {
-    padding: 1rem;
+.hero-trend {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin: 4px 0 0;
 }
 
-.metric-card.dark,
-.dashboard-card.dark {
-    background: var(--graphite);
-    border-color: var(--graphite);
-    color: #edf5ee;
+.kpi-value {
+  font-size: clamp(16px, 2vw, 17px);
+  font-weight: 500;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.3;
 }
 
-.card-label,
-.metric-label,
-.muted {
-    color: var(--text-muted);
-    font-size: .78rem;
+.kpi-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 2px 0 0;
 }
 
-.card-label,
-.metric-label {
-    margin-bottom: .35rem;
-    font-weight: 780;
-    letter-spacing: .06em;
-    text-transform: uppercase;
+.section-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  margin: 0;
 }
 
-.card-value,
-.metric-value {
-    color: inherit;
-    font-size: clamp(1.45rem, 3vw, 2rem);
-    font-weight: 820;
-    line-height: 1.1;
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
 }
 
-.card-sub,
-.metric-sub {
-    margin-top: .3rem;
-    color: var(--text-muted);
-    font-size: .84rem;
+.section-header .section-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
 }
 
-.dark .card-sub,
-.dark .metric-sub,
-.dark .card-label,
-.dark .metric-label {
-    color: #b8c8bd;
+.section-link {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  text-decoration: none;
 }
 
-/* === Buttons === */
+.section-link:hover {
+  color: var(--accent-hover);
+}
+
+/* Labels */
+.field-label,
+label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+/* === 7. Buttons === */
+
 .btn,
-a[role="button"],
-button,
-input[type="submit"] {
-    border-radius: var(--radius);
-    font-weight: 730;
+[data-theme] button,
+[data-theme] a[role="button"],
+[data-theme] input[type="submit"],
+[data-theme] summary.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 7px;
+  font-weight: 500;
+  font-size: 13px;
+  padding: 7px 16px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, box-shadow 0.15s;
+  text-decoration: none;
+  line-height: 1.3;
+  border: 1px solid transparent;
 }
 
-.btn-primary,
-form .btn-primary,
-summary.btn-primary {
-    border-color: var(--graphite) !important;
-    background: var(--graphite) !important;
-    color: #fff !important;
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
 }
 
-.btn-primary:hover,
-form .btn-primary:hover,
-summary.btn-primary:hover {
-    border-color: var(--graphite-2) !important;
-    background: var(--graphite-2) !important;
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
-.btn-outline,
-a.outline {
-    border: 1px solid var(--line-strong) !important;
-    background: var(--surface) !important;
-    color: var(--text) !important;
+.btn-secondary,
+.btn-outline {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border-color);
+}
+
+.btn-secondary:hover,
+.btn-outline:hover {
+  border-color: var(--text-muted);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--accent);
+  border-color: transparent;
+}
+
+.btn-ghost:hover {
+  background: var(--accent-muted);
 }
 
 .btn-sm {
-    padding: .45rem .65rem;
-    font-size: .84rem;
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 6px;
 }
 
 .btn-icon {
-    width: 30px;
-    height: 30px;
-    display: inline-grid;
-    place-items: center;
-    border: 1px solid var(--line);
-    background: transparent;
-    color: var(--text-muted);
-    border-radius: var(--radius-sm);
-    padding: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  padding: 0;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btn-icon:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
 }
 
 .btn-icon.danger:hover {
-    border-color: rgba(189, 62, 62, .3);
-    background: rgba(189, 62, 62, .08);
-    color: var(--negative);
+  border-color: rgba(189,62,62,0.3);
+  background: rgba(189,62,62,0.08);
+  color: var(--negative);
 }
 
-/* === Forms === */
+/* Pico outline override - match btn-secondary */
+[data-theme] a[role="button"].outline,
+[data-theme] button.outline {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border-color);
+}
+
+[data-theme] a[role="button"].outline:hover,
+[data-theme] button.outline:hover {
+  border-color: var(--text-muted);
+}
+
+/* === 8. Forms === */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 9px 12px;
+  background: var(--surface);
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.04);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  gap: 6px;
+}
+
+.input-wrap:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
+}
+
+.input-wrap input,
+.input-wrap select,
+.input-wrap textarea {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  outline: none;
+  width: 100%;
+  padding: 0;
+  font-size: 13px;
+  box-shadow: none;
+  margin: 0;
+}
+
+.input-wrap input::placeholder {
+  color: var(--text-muted);
+}
+
+.input-deco {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
 .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-    gap: .85rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 12px;
 }
 
 .form-full {
-    grid-column: 1 / -1;
+  grid-column: 1 / -1;
 }
 
 .inline-form,
 .txn-form,
 .import-form {
-    display: grid;
-    gap: .9rem;
+  display: grid;
+  gap: 12px;
 }
 
-label {
-    color: var(--text-muted);
-    font-size: .82rem;
-    font-weight: 700;
+.form-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
 }
 
-input,
-select,
-textarea {
-    border-color: var(--line-strong) !important;
-    background-color: var(--surface) !important;
-    color: var(--text) !important;
+.form-checkbox input[type="checkbox"] {
+  width: auto;
 }
 
-details.add-section,
-.add-txn-section details {
-    margin-bottom: 1rem;
+[data-theme] input,
+[data-theme] select,
+[data-theme] textarea {
+  border-color: var(--border-color);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 7px;
+  font-size: 13px;
 }
 
-details > summary {
-    cursor: pointer;
-    list-style: none;
-}
+/* === 9. Badges & Chips === */
 
-details > summary::-webkit-details-marker {
-    display: none;
-}
-
-/* === Badges & Chips === */
 .badge {
-    display: inline-flex;
-    align-items: center;
-    min-height: 24px;
-    border: 1px solid var(--line);
-    border-radius: 999px;
-    padding: .18rem .55rem;
-    background: var(--surface-muted);
-    color: var(--text);
-    font-size: .76rem;
-    font-weight: 760;
-    white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 400;
+  border-radius: 5px;
+  background: var(--surface-muted);
+  color: var(--text);
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.badge-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: currentColor;
+}
+
+.badge-emphasis {
+  background: var(--accent);
+  color: #fff;
+}
+
+.badge-emphasis .badge-dot {
+  display: none;
 }
 
 .category-badge {
-    border-color: color-mix(in srgb, var(--cat-color, var(--line)) 35%, var(--line));
-    background: color-mix(in srgb, var(--cat-color, var(--surface-muted)) 14%, var(--surface));
+  background: color-mix(in srgb, var(--cat-color, var(--surface-muted)) 14%, var(--surface));
+  color: var(--text);
 }
 
 .type-badge,
 .period-badge {
-    background: #eef6e7;
-    border-color: #d8e8ca;
-    color: #365225;
+  background: var(--surface-muted);
+  text-transform: capitalize;
 }
 
-/* === Amount Colors === */
-.amount-positive,
-.positive {
-    color: var(--positive) !important;
+/* Filter Chips (segmented control) */
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
-.amount-negative,
-.negative {
-    color: var(--negative) !important;
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
 }
 
-.amount-zero,
-.no-data {
-    color: var(--text-muted) !important;
+.chip:hover {
+  border-color: var(--text-muted);
 }
 
-/* === Tables === */
+.chip-active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.chip-active:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+/* === 10. Progress Bars === */
+
+.progress-track {
+  width: 100%;
+  height: 3px;
+  background: var(--surface-muted);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.progress-fill.safe {
+  background: var(--positive);
+}
+
+.progress-fill.warning {
+  background: var(--warning);
+}
+
+.progress-fill.danger {
+  background: var(--negative);
+}
+
+.budget-item {
+  margin-bottom: 14px;
+}
+
+.budget-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.budget-cat {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.budget-amounts {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* === 11. Tables === */
+
+.table-container,
 .table-wrapper {
-    overflow-x: auto;
-    padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+  overflow-x: auto;
 }
 
-.txn-table,
-.data-table,
-.table-striped {
-    width: 100%;
-    border-collapse: separate;
-    border-spacing: 0;
+.table-container table,
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0;
 }
 
-.txn-table th,
-.data-table th,
-.table-striped th {
-    padding: .72rem .85rem;
-    border-bottom: 1px solid var(--line);
-    color: var(--text-muted);
-    font-size: .72rem;
-    font-weight: 820;
-    letter-spacing: .06em;
-    text-align: left;
-    text-transform: uppercase;
+.table-container thead th,
+.table-wrapper thead th {
+  padding: 10px 14px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
 }
 
-.txn-table td,
-.data-table td,
-.table-striped td {
-    padding: .78rem .85rem;
-    border-bottom: 1px solid var(--line);
-    color: var(--text);
-    font-size: .9rem;
-    vertical-align: middle;
+.table-container tbody td,
+.table-wrapper tbody td {
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--text);
+  border-bottom: 1px solid var(--line-faint);
+  vertical-align: middle;
 }
 
-.txn-table tr:last-child td,
-.data-table tr:last-child td,
-.table-striped tr:last-child td {
-    border-bottom: 0;
+.table-container tbody tr:last-child td,
+.table-wrapper tbody tr:last-child td {
+  border-bottom: none;
 }
 
-.txn-row:hover,
-.data-table tbody tr:hover,
-.table-striped tbody tr:hover {
-    background: color-mix(in srgb, var(--lime) 8%, transparent);
+.table-container tbody tr:hover,
+.table-wrapper tbody tr:hover {
+  background: rgba(194,90,62,0.03);
+}
+
+[data-theme="dark"] .table-container tbody tr:hover,
+[data-theme="dark"] .table-wrapper tbody tr:hover {
+  background: rgba(208,122,95,0.05);
 }
 
 .amount-col,
 .action-col,
 .txn-amount {
-    text-align: right;
-    white-space: nowrap;
+  text-align: right;
+  white-space: nowrap;
 }
 
-/* === Empty State === */
+/* === 12. KPI Strip === */
+
+.kpi-strip {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 1.5rem;
+}
+
+.kpi-item {
+  flex: 1;
+  padding: 0 16px;
+}
+
+.kpi-item:first-child {
+  padding-left: 0;
+}
+
+.kpi-item:last-child {
+  padding-right: 0;
+}
+
+.kpi-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--line);
+  flex-shrink: 0;
+}
+
+/* === 13. Empty State === */
+
 .empty-state {
-    display: grid;
-    place-items: center;
-    gap: .55rem;
-    min-height: 180px;
-    padding: 2rem 1rem;
-    border: 1px dashed var(--line-strong);
-    border-radius: var(--radius);
-    background: color-mix(in srgb, var(--surface) 72%, var(--canvas));
-    color: var(--text-muted);
-    text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 2.5rem 2rem;
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+  text-align: center;
+  color: var(--text-muted);
+  min-height: 160px;
 }
 
 .empty-state .empty-icon {
-    font-size: 1.6rem;
+  font-size: 28px;
+  color: var(--text-muted);
+  line-height: 1;
 }
 
-.section-title {
-    margin: 1.5rem 0 .75rem;
-    color: var(--text);
-    font-size: 1rem;
-    font-weight: 820;
+.empty-state p {
+  margin: 0;
+  font-size: 14px;
 }
 
-/* === Dashboard Specific === */
-.dashboard-metrics {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+/* === 14. Theme Toggle === */
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px;
+  background: var(--surface);
+  cursor: pointer;
 }
 
-.section-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-top: 1.35rem;
+.theme-option {
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: all 0.15s;
+  border: none;
+  background: transparent;
 }
 
-.subtle-link {
-    color: var(--text-muted);
-    font-size: .85rem;
-    font-weight: 760;
-    text-decoration: none;
+.theme-option-active {
+  background: var(--accent);
+  color: #fff;
 }
 
-.subtle-link:hover {
-    color: var(--text);
+/* === 15. Charts & Heatmap === */
+
+.chart-container {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
 }
 
-.budget-bar {
-    width: 100%;
-    height: 9px;
-    margin-top: .65rem;
-    overflow: hidden;
-    border-radius: 999px;
-    background: var(--surface-muted);
-}
-
-.budget-bar-fill {
-    height: 100%;
-    border-radius: inherit;
-}
-
-.budget-bar-fill.safe {
-    background: var(--lime);
-}
-
-.budget-bar-fill.warning {
-    background: #f2b84b;
-}
-
-.budget-bar-fill.danger {
-    background: var(--negative);
+.chart-svg {
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 .chart-container canvas {
-    width: 100%;
-    max-height: 400px;
+  width: 100%;
+  max-height: 400px;
 }
 
-/* === Transactions Specific === */
-.filters-form {
-    display: grid;
-    gap: .75rem;
+/* Heatmap */
+.heatmap {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 8px;
 }
 
-.filter-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: .65rem;
-    align-items: end;
+.heatmap-col {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
 }
 
-.filter-actions {
-    display: flex;
-    gap: .5rem;
-    justify-content: flex-end;
+.cell-label {
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--text-muted);
+  height: 12px;
+  line-height: 12px;
+  margin-bottom: 2px;
+}
+
+.heatmap-cell {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 2px;
+  max-width: 14px;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.heatmap-legend .heatmap-cell {
+  width: 12px;
+  aspect-ratio: 1;
+}
+
+/* Heatmap levels — light mode */
+.level-0,
+.heatmap-level-0 {
+  background: var(--surface-muted);
+}
+
+.level-1,
+.heatmap-level-1 {
+  background: #ffe4dd;
+}
+
+.level-2,
+.heatmap-level-2 {
+  background: rgba(194,90,62,0.2);
+}
+
+.level-3,
+.heatmap-level-3 {
+  background: rgba(194,90,62,0.4);
+}
+
+.level-4,
+.heatmap-level-4 {
+  background: var(--accent);
+}
+
+.level-5,
+.heatmap-level-5 {
+  background: #8a3a2a;
+}
+
+/* Heatmap levels — dark mode */
+[data-theme="dark"] .level-1,
+[data-theme="dark"] .heatmap-level-1 {
+  background: rgba(208,122,95,0.12);
+}
+
+[data-theme="dark"] .level-2,
+[data-theme="dark"] .heatmap-level-2 {
+  background: rgba(208,122,95,0.25);
+}
+
+[data-theme="dark"] .level-3,
+[data-theme="dark"] .heatmap-level-3 {
+  background: rgba(208,122,95,0.4);
+}
+
+[data-theme="dark"] .level-4,
+[data-theme="dark"] .heatmap-level-4 {
+  background: var(--accent);
+}
+
+[data-theme="dark"] .level-5,
+[data-theme="dark"] .heatmap-level-5 {
+  background: #8a3a2a;
+}
+
+/* === 16. Dashboard Grid === */
+
+.content-grid,
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 20px;
+  margin-top: 1.5rem;
+}
+
+/* Transaction rows (dashboard) */
+.txn-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-faint);
+}
+
+.txn-row:last-child {
+  border-bottom: none;
+}
+
+.txn-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.txn-dot.positive {
+  background: var(--positive);
+}
+
+.txn-dot.negative {
+  background: var(--negative);
+}
+
+.txn-desc {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.txn-badge {
+  flex-shrink: 0;
+}
+
+.txn-amount {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Transaction table cells */
+.txn-date {
+  color: var(--text-muted);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.date-display {
+  color: var(--text-muted);
 }
 
 .txn-title {
-    min-width: 180px;
+  min-width: 0;
+}
+
+.txn-title strong {
+  font-weight: 500;
+  color: var(--text);
 }
 
 .txn-kind {
-    display: block;
-    margin-top: .12rem;
-    color: var(--text-muted);
-    font-size: .76rem;
-    text-transform: capitalize;
+  display: block;
+  margin-top: 1px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: capitalize;
 }
 
-.txn-date {
-    color: var(--text-muted);
-    white-space: nowrap;
+/* === 17. Filters === */
+
+.filters-bar {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 1.25rem;
 }
 
-.pagination {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-top: 1rem;
+.filters-form {
+  display: grid;
+  gap: 10px;
 }
 
-.txn-count {
-    color: var(--text-muted);
-    font-size: .85rem;
+.filter-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  align-items: end;
 }
 
-/* === Report/Settings/Auth Tiles === */
-.report-card,
+.filter-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* === 18. Settings Grid === */
+
+.settings-grid,
+.tile-grid,
+.report-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  margin-bottom: 1.5rem;
+}
+
 .settings-card,
+.report-card,
 .export-card {
-    position: relative;
-    display: block;
-    min-height: 132px;
-    color: var(--text) !important;
-    text-decoration: none !important;
+  position: relative;
+  display: block;
+  min-height: 120px;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 0.15s;
 }
 
-.report-card:hover,
 .settings-card:hover,
+.report-card:hover,
 .export-card:hover {
-    border-color: var(--line-strong);
-    box-shadow: var(--shadow-soft);
-    transform: translateY(-1px);
+  border-color: var(--border-color);
 }
 
-.report-card h3,
 .settings-card h3,
+.report-card h3,
 .export-card h3 {
-    margin: 0 0 .45rem;
-    font-size: 1rem;
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
 }
 
-.report-card p,
 .settings-card p,
-.export-card p,
-.auth-subtitle,
-.auth-footer {
-    color: var(--text-muted);
-    font-size: .88rem;
+.report-card p,
+.export-card p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.4;
 }
 
-.report-arrow,
 .settings-arrow,
+.report-arrow,
 .export-arrow {
-    position: absolute;
-    right: 1rem;
-    bottom: 1rem;
-    color: var(--graphite);
-    font-weight: 850;
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  color: var(--text-muted);
+  font-size: 16px;
 }
 
-/* === Auth Pages === */
-.auth-page {
-    display: grid;
-    place-items: center;
-    min-height: calc(100vh - 4rem);
+.settings-section {
+  margin-top: 2rem;
 }
 
-.auth-card {
-    width: min(100%, 420px);
-    box-shadow: var(--shadow-soft);
-}
+/* === 19. Flash Messages === */
 
-.auth-card h1 {
-    margin-bottom: .25rem;
-}
-
-.auth-footer {
-    margin-top: 1rem;
-    text-align: center;
-}
-
-.w-full {
-    width: 100%;
-}
-
-/* === Import/Export === */
-.import-box {
-    display: grid;
-    gap: .75rem;
-    min-height: 180px;
-    place-items: center;
-    text-align: center;
-}
-
-.file-label {
-    display: grid;
-    gap: .5rem;
-    place-items: center;
-}
-
-.file-icon {
-    width: 42px;
-    height: 42px;
-    display: grid;
-    place-items: center;
-    border-radius: var(--radius);
-    background: var(--lime);
-    color: var(--graphite);
-    font-weight: 850;
-}
-
-.back-link {
-    display: inline-flex;
-    margin-top: 1rem;
-    color: var(--text-muted);
-    font-size: .86rem;
-    font-weight: 760;
-    text-decoration: none;
-}
-
-/* === Flash Messages === */
 .flashes {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
 .flash {
-    padding: .75rem 1rem;
-    border-radius: var(--radius);
-    font-size: .9rem;
-    margin-bottom: .5rem;
+  padding: 10px 14px;
+  border-radius: 7px;
+  font-size: 13px;
+  margin-bottom: 8px;
+  border: 1px solid transparent;
 }
 
-.flash-success { background: rgba(22, 131, 90, .12); color: var(--positive); border: 1px solid rgba(22, 131, 90, .3); }
-.flash-error { background: rgba(189, 62, 62, .12); color: var(--negative); border: 1px solid rgba(189, 62, 62, .3); }
-.flash-info { background: rgba(37, 99, 235, .12); color: var(--info); border: 1px solid rgba(37, 99, 235, .3); }
-
-/* === HTMX Utilities === */
-.htmx-indicator { opacity: 0; transition: opacity .2s; }
-.htmx-request .htmx-indicator { opacity: 1; }
-.htmx-request.htmx-indicator { opacity: 1; }
-
-[x-cloak] { display: none !important; }
-
-/* === Color Swatch === */
-.color-swatch {
-    display: inline-block;
-    width: 22px;
-    height: 22px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--line);
-    vertical-align: middle;
+.flash-success {
+  background: rgba(22,131,90,0.1);
+  color: var(--positive);
+  border-color: rgba(22,131,90,0.25);
 }
 
-/* === Skip Link === */
+.flash-error {
+  background: rgba(189,62,62,0.1);
+  color: var(--negative);
+  border-color: rgba(189,62,62,0.25);
+}
+
+.flash-info {
+  background: rgba(37,99,235,0.1);
+  color: var(--info);
+  border-color: rgba(37,99,235,0.25);
+}
+
+/* === 20. Amount Colors === */
+
+.amount-positive,
+.positive {
+  color: var(--positive);
+}
+
+.amount-negative,
+.negative {
+  color: var(--negative);
+}
+
+.amount-zero,
+.no-data {
+  color: var(--text-muted);
+}
+
+/* === 21. Pagination === */
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.txn-count {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* === 22. Bottom Tab Bar (Mobile) === */
+
+.bottom-nav {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  z-index: 100;
+  justify-content: space-around;
+  align-items: center;
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.bottom-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 9px;
+  font-weight: 500;
+  transition: color 0.15s;
+  padding: 6px 12px;
+  min-width: 0;
+}
+
+.bottom-nav-item svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+  stroke: none;
+}
+
+.bottom-nav-item:hover {
+  color: var(--text);
+}
+
+.bottom-nav-active {
+  color: var(--accent);
+}
+
+/* === 23. Add/Edit Section === */
+
+details.add-section,
+.add-txn-section details {
+  margin-bottom: 1rem;
+}
+
+details > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* === 24. Auth === */
+
+.auth-page {
+  display: grid;
+  place-items: center;
+  min-height: calc(100vh - 4rem);
+}
+
+.auth-card {
+  width: min(100%, 420px);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.auth-card h1 {
+  margin-bottom: 4px;
+}
+
+.auth-subtitle,
+.auth-footer {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.auth-footer {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+/* === 25. Import === */
+
+.import-box {
+  display: grid;
+  gap: 12px;
+  min-height: 180px;
+  place-items: center;
+  text-align: center;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.file-label {
+  display: grid;
+  gap: 8px;
+  place-items: center;
+}
+
+.file-icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.back-link {
+  display: inline-flex;
+  margin-top: 1rem;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  color: var(--text);
+}
+
+/* === 26. Utilities === */
+
+.htmx-indicator {
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator {
+  opacity: 1;
+}
+
+[x-cloak] {
+  display: none !important;
+}
+
 .skip-link {
-    position: absolute;
-    top: -40px;
-    left: 0;
-    padding: .5rem 1rem;
-    background: var(--graphite);
-    color: #fff;
-    z-index: 1000;
-    transition: top .15s;
-    text-decoration: none;
-    font-weight: 760;
-    border-radius: 0 0 var(--radius) 0;
+  position: absolute;
+  top: -40px;
+  left: 0;
+  padding: 8px 16px;
+  background: var(--sidebar-bg);
+  color: #fff;
+  z-index: 1000;
+  transition: top 0.15s;
+  text-decoration: none;
+  font-weight: 500;
+  border-radius: 0 0 7px 0;
+  font-size: 13px;
 }
 
 .skip-link:focus {
-    top: 0;
-    outline: 3px solid var(--lime);
+  top: 0;
+  outline: 2px solid var(--accent);
 }
 
-/* === Responsive === */
-@media (max-width: 980px) {
-    .dashboard-metrics {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+.w-full {
+  width: 100%;
 }
 
-@media (max-width: 860px) {
-    .app-layout {
-        display: block;
-    }
+/* === 27. Responsive === */
 
-    .sidebar {
-        position: sticky;
-        height: auto;
-        min-height: 0;
-        border-right: 0;
-        border-bottom: 1px solid rgba(215, 255, 103, .12);
-    }
+/* Tablet: 620-768px */
+@media (max-width: 768px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
 
-    .sidebar-top {
-        padding: .75rem 1rem;
-    }
+  .sidebar {
+    display: none;
+  }
 
-    .mobile-toggle {
-        display: inline-flex;
-    }
+  .bottom-nav {
+    display: flex;
+  }
 
-    .sidebar-links {
-        display: none;
-        padding: 0 1rem 1rem;
-    }
+  .content,
+  .main-content {
+    padding: 1rem 1rem calc(56px + env(safe-area-inset-bottom, 0px) + 1rem);
+  }
 
-    .sidebar-links.open {
-        display: flex;
-    }
+  .kpi-strip {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
 
-    .nav-logout {
-        margin-top: 0;
-    }
+  .kpi-item {
+    padding: 0;
+  }
 
-    .main-content {
-        padding: 1rem;
-    }
+  .kpi-divider {
+    display: none;
+  }
 
-    .page-header {
-        align-items: flex-start;
-    }
+  .content-grid,
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
 
-    .card-grid,
-    .metric-grid,
-    .tile-grid,
-    .report-grid,
-    .settings-grid,
-    .export-options,
-    .two-col {
-        grid-template-columns: 1fr;
-    }
+  .settings-grid,
+  .tile-grid,
+  .report-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
-    .dashboard-metrics {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+  .page-header {
+    margin-bottom: 1rem;
+  }
 }
 
+/* Mobile: <620px */
 @media (max-width: 620px) {
-    .dashboard-metrics {
-        grid-template-columns: 1fr;
-    }
+  .kpi-strip {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .settings-grid,
+  .tile-grid,
+  .report-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-row {
+    grid-template-columns: 1fr;
+  }
+
+  .table-wrapper table {
+    min-width: 560px;
+  }
+
+  .chart-container {
+    display: none;
+  }
+
+  .content,
+  .main-content {
+    padding: 0.75rem 0.75rem calc(56px + env(safe-area-inset-bottom, 0px) + 1rem);
+  }
+
+  .hero-number {
+    font-size: clamp(32px, 8vw, 38px);
+  }
+
+  .page-header h1,
+  .page-title {
+    font-size: 20px;
+  }
+}
+
+/* === 28. Dark Mode Specific Overrides === */
+
+[data-theme="dark"] .sidebar {
+  border-right: 1px solid rgba(255,255,255,0.04);
+}
+
+[data-theme="dark"] .btn-secondary,
+[data-theme="dark"] .btn-outline,
+[data-theme="dark"] a[role="button"].outline,
+[data-theme="dark"] button.outline {
+  background: transparent;
+  border-color: var(--border-color);
+  color: var(--text);
+}
+
+[data-theme="dark"] .category-badge {
+  background: color-mix(in srgb, var(--cat-color, var(--surface-muted)) 18%, var(--surface));
+}
+
+[data-theme="dark"] .chip {
+  background: transparent;
+}
+
+[data-theme="dark"] .theme-toggle {
+  background: transparent;
 }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -23,16 +23,13 @@
         {{template "nav.html" .}}
         <main id="main-content" class="main-content">
             <header class="page-header">
-                <div>
-                    <p class="page-kicker">Ledgerify</p>
-                    <h1>{{.Title}}</h1>
-                </div>
+                <h1>{{.Title}}</h1>
                 <div class="header-actions">
                     <button class="theme-toggle"
                             aria-label="Toggle theme"
                             @click="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'; $dispatch('theme-changed')">
-                        <span x-show="document.documentElement.dataset.theme === 'dark'">Light</span>
-                        <span x-show="document.documentElement.dataset.theme === 'light'" x-cloak>Dark</span>
+                        <span x-show="document.documentElement.dataset.theme === 'dark'">☀️ Light</span>
+                        <span x-show="document.documentElement.dataset.theme === 'light'" x-cloak>🌙 Dark</span>
                     </button>
                 </div>
             </header>
@@ -40,7 +37,7 @@
             {{if .Flashes}}
             <div class="flashes">
                 {{range .Flashes}}
-                <article class="flash flash-{{.Type}}">{{.Message}}</article>
+                <div class="flash flash-{{.Type}}">{{.Message}}</div>
                 {{end}}
             </div>
             {{end}}

--- a/web/templates/pages/accounts.html
+++ b/web/templates/pages/accounts.html
@@ -1,49 +1,65 @@
 {{define "content"}}
 
-<!-- Add Account Form -->
-<details class="add-section">
-    <summary class="btn btn-primary">Add Account</summary>
-    <form method="post" action="/accounts" class="inline-form">
-        <div class="form-grid">
-            <label>
-                Name *
-                <input type="text" name="name" required placeholder="e.g. Chase Checking">
-            </label>
-            <label>
-                Type *
-                <select name="type" required>
-                    <option value="">Choose type…</option>
-                    <option value="checking">Checking</option>
-                    <option value="savings">Savings</option>
-                    <option value="credit_card">Credit Card</option>
-                    <option value="investment">Investment</option>
-                    <option value="loan">Loan</option>
-                    <option value="cash">Cash</option>
-                    <option value="other">Other</option>
-                </select>
-            </label>
-            <label>
-                Currency
-                <input type="text" name="currency" value="USD" maxlength="3">
-            </label>
-            <label>
-                Opening Balance
-                <input type="number" name="opening_balance" step="0.01" placeholder="0.00">
-            </label>
+<div style="display:flex;align-items:start;justify-content:space-between;gap:16px;margin-bottom:16px;flex-wrap:wrap">
+    <div class="field" style="flex:1;min-width:200px">
+        <label class="field-label">Search</label>
+        <div class="input-wrap">
+            <input type="text" placeholder="Search accounts…" x-data x-on:input.debounce="window.location = '/accounts?search=' + encodeURIComponent($el.value)" value="">
         </div>
-        <button type="submit" class="btn btn-primary">Create Account</button>
-    </form>
-</details>
+    </div>
+    <details class="add-section" style="flex-shrink:0">
+        <summary class="btn btn-primary">+ Add Account</summary>
+        <form method="post" action="/accounts" class="txn-form" style="position:absolute;right:0;top:100%;width:450px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
+            <div class="form-grid">
+                <div class="field">
+                    <label class="field-label">Name</label>
+                    <div class="input-wrap">
+                        <input type="text" name="name" required placeholder="e.g. Chase Checking">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Type</label>
+                    <div class="input-wrap">
+                        <select name="type" required>
+                            <option value="">Choose type…</option>
+                            <option value="checking">Checking</option>
+                            <option value="savings">Savings</option>
+                            <option value="credit_card">Credit Card</option>
+                            <option value="investment">Investment</option>
+                            <option value="loan">Loan</option>
+                            <option value="cash">Cash</option>
+                            <option value="other">Other</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Currency</label>
+                    <div class="input-wrap">
+                        <input type="text" name="currency" value="USD" maxlength="3">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Opening Balance</label>
+                    <div class="input-wrap">
+                        <span class="input-deco">$</span>
+                        <input type="number" name="opening_balance" step="0.01" placeholder="0.00">
+                    </div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Account</button>
+        </form>
+    </details>
+</div>
 
-<!-- Accounts List -->
+<!-- Accounts Table -->
 {{if .Data}}
-<div class="table-wrapper">
-    <table class="data-table">
+<div class="table-container">
+    <table>
         <thead>
             <tr>
                 <th>Name</th>
                 <th>Type</th>
-                <th>Balance</th>
+                <th class="amount-col">Balance</th>
                 <th>Currency</th>
                 <th>Created</th>
             </tr>
@@ -52,8 +68,8 @@
             {{range .Data}}
             <tr>
                 <td><strong>{{.Name}}</strong></td>
-                <td><span class="badge type-badge">{{.Type}}</span></td>
-                <td class="{{if gt .Balance 0.0}}positive{{else if lt .Balance 0.0}}negative{{end}}">{{printf "%.2f" .Balance}}</td>
+                <td><span class="badge">{{.Type}}</span></td>
+                <td class="txn-amount {{if gt .Balance 0.0}}positive{{else if lt .Balance 0.0}}negative{{end}}">{{printf "%.2f" .Balance}}</td>
                 <td>{{.Currency}}</td>
                 <td>{{.CreatedAt}}</td>
             </tr>
@@ -63,7 +79,8 @@
 </div>
 {{else}}
 <div class="empty-state">
-    <p>No accounts yet. Add your first account above.</p>
+    <p>No accounts yet.</p>
+    <p>Add your first account to start tracking.</p>
 </div>
 {{end}}
 

--- a/web/templates/pages/budgets.html
+++ b/web/templates/pages/budgets.html
@@ -1,88 +1,97 @@
 {{define "content"}}
 
-<!-- Add Budget Form -->
-<details class="add-section">
-    <summary class="btn btn-primary">Add Budget</summary>
-    <form method="post" action="/budgets" class="inline-form">
-        <div class="form-grid">
-            <label>
-                Name *
-                <input type="text" name="name" required placeholder="e.g. Monthly Groceries">
-            </label>
-            <label>
-                Amount *
-                <input type="number" name="amount" step="0.01" min="0.01" required placeholder="0.00">
-            </label>
-            <label>
-                Currency
-                <input type="text" name="currency" value="USD" maxlength="3">
-            </label>
-            <label>
-                Period *
-                <select name="period_type" required>
-                    <option value="">Choose period…</option>
-                    <option value="weekly">Weekly</option>
-                    <option value="monthly">Monthly</option>
-                    <option value="quarterly">Quarterly</option>
-                    <option value="yearly">Yearly</option>
-                    <option value="one_time">One Time</option>
-                    <option value="custom">Custom</option>
-                </select>
-            </label>
-            <label>
-                Category
-                <input type="text" name="category_id" placeholder="Category ID (UUID)">
-            </label>
-            <label>
-                Start Date
-                <input type="date" name="start_date" value="{{(now).Format "2006-01-02"}}">
-            </label>
-            <label class="form-checkbox">
-                <input type="checkbox" name="rollover">
-                Rollover unused amount
-            </label>
-        </div>
-        <button type="submit" class="btn btn-primary">Create Budget</button>
-    </form>
-</details>
+<div style="display:flex;align-items:start;justify-content:space-between;gap:16px;margin-bottom:16px;flex-wrap:wrap">
+    <div></div>
+    <details class="add-section" style="flex-shrink:0">
+        <summary class="btn btn-primary">+ Set Budget</summary>
+        <form method="post" action="/budgets" class="txn-form" style="position:absolute;right:0;top:100%;width:450px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
+            <div class="form-grid">
+                <div class="field">
+                    <label class="field-label">Name</label>
+                    <div class="input-wrap">
+                        <input type="text" name="name" required placeholder="e.g. Monthly Groceries">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Amount</label>
+                    <div class="input-wrap">
+                        <span class="input-deco">$</span>
+                        <input type="number" name="amount" step="0.01" min="0.01" required placeholder="0.00">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Currency</label>
+                    <div class="input-wrap">
+                        <input type="text" name="currency" value="USD" maxlength="3">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Period</label>
+                    <div class="input-wrap">
+                        <select name="period_type" required>
+                            <option value="">Choose period…</option>
+                            <option value="weekly">Weekly</option>
+                            <option value="monthly">Monthly</option>
+                            <option value="quarterly">Quarterly</option>
+                            <option value="yearly">Yearly</option>
+                            <option value="one_time">One Time</option>
+                            <option value="custom">Custom</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Category ID</label>
+                    <div class="input-wrap">
+                        <input type="text" name="category_id" placeholder="Category ID (UUID)">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Start Date</label>
+                    <div class="input-wrap">
+                        <input type="date" name="start_date" value="{{(now).Format "2006-01-02"}}">
+                    </div>
+                </div>
+                <div class="field" style="flex-direction:row;align-items:center;gap:8px">
+                    <input type="checkbox" name="rollover" id="budget-rollover" style="width:auto">
+                    <label for="budget-rollover" style="font-size:12px;color:var(--text-muted);text-transform:none;letter-spacing:0;font-weight:400">Rollover unused amount</label>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Budget</button>
+        </form>
+    </details>
+</div>
 
-<!-- Budgets List -->
+<!-- Budget Cards -->
 {{if .Data}}
-<div class="table-wrapper">
-    <table class="data-table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Category</th>
-                <th>Amount</th>
-                <th>Period</th>
-                <th>Dates</th>
-                <th>Rollover</th>
-            </tr>
-        </thead>
-        <tbody>
-            {{range .Data}}
-            <tr>
-                <td><strong>{{.Name}}</strong></td>
-                <td>
+<div class="budget-grid">
+    {{range .Data}}
+    <div class="budget-card">
+        <div class="budget-card-header">
+            <div>
+                <div class="budget-card-category">
                     {{if .CategoryName}}
-                    <span class="badge category-badge" style="--cat-color: {{defaultStr .CategoryColor "#6b7280"}}">{{.CategoryName}}</span>
-                    {{else}}
-                    <span class="no-data">—</span>
+                    <span class="badge category-badge" style="--cat-color: {{defaultStr .CategoryColor "#6b7280"}}">
+                        <span class="badge-dot" style="background:{{defaultStr .CategoryColor "#6b7280"}}"></span>
+                        {{.CategoryName}}
+                    </span>
                     {{end}}
-                </td>
-                <td>{{formatCurrency .Amount .Currency}}</td>
-                <td><span class="badge period-badge">{{.PeriodType}}</span></td>
-                <td>{{.StartDate}} → {{.EndDate}}</td>
-                <td>{{if .Rollover}}✓{{else}}—{{end}}</td>
-            </tr>
-            {{end}}
-        </tbody>
-    </table>
+                    {{.Name}}
+                </div>
+            </div>
+            <div class="budget-card-amount">{{formatCurrency .Amount .Currency}}</div>
+        </div>
+        <div class="budget-card-subtitle">{{.PeriodType}} budget</div>
+        <div class="budget-card-meta">
+            <span>{{.StartDate}} → {{.EndDate}}</span>
+            <span>{{if .Rollover}}Rollover✓{{else}}{{end}}</span>
+        </div>
+    </div>
+    {{end}}
 </div>
 {{else}}
 <div class="empty-state">
-    <p>No budgets yet. Add your first budget above.</p>
+    <p>No budgets yet.</p>
+    <p>Set your first budget to start tracking spending.</p>
 </div>
 {{end}}
 

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -1,134 +1,210 @@
 {{define "content"}}
 
-<!-- Summary Cards -->
-<div class="metric-grid dashboard-metrics">
-    <div class="metric-card">
-        <div class="metric-label">Income</div>
-        <div class="metric-value positive">{{formatCurrency .Data.TotalIncome .Data.Currency}}</div>
-        <div class="metric-sub">This month</div>
-    </div>
-    <div class="metric-card">
-        <div class="metric-label">Spend</div>
-        <div class="metric-value negative">{{formatCurrency .Data.TotalExpenses .Data.Currency}}</div>
-        <div class="metric-sub">This month</div>
-    </div>
-    <div class="metric-card dark">
-        <div class="metric-label">Net</div>
-        <div class="metric-value {{amountClass .Data.NetAmount}}">{{formatAmount .Data.NetAmount .Data.Currency}}</div>
-        <div class="metric-sub">Income minus spend</div>
-    </div>
-    <div class="metric-card">
-        <div class="metric-label">Balance</div>
-        <div class="metric-value">{{formatCurrency .Data.TotalBalance .Data.Currency}}</div>
-        <div class="metric-sub">{{.Data.AccountCount}} accounts</div>
-    </div>
+{{$pts := .Data.MonthlyNetworth}}
+{{$n := len $pts}}
+
+<!-- Net Worth Hero -->
+<div class="hero-section">
+  <p class="hero-label">NET WORTH</p>
+  <p class="hero-number">{{formatCurrency .Data.TotalBalance .Data.Currency}}</p>
+  <p class="hero-trend {{amountClass .Data.NetAmount}}">{{formatAmount .Data.NetAmount .Data.Currency}} this month</p>
 </div>
 
-<!-- Recent Transactions -->
-<div class="section-row">
-    <h2 class="section-title">Recent Transactions</h2>
-    <a href="/transactions" class="subtle-link">View all</a>
+<!-- KPI Strip -->
+<div class="kpi-strip">
+  <div class="kpi-item">
+    <p class="kpi-value">{{formatCurrency .Data.TotalIncome .Data.Currency}}</p>
+    <p class="kpi-label">Income</p>
+  </div>
+  <div class="kpi-divider"></div>
+  <div class="kpi-item">
+    <p class="kpi-value">{{formatCurrency .Data.TotalExpenses .Data.Currency}}</p>
+    <p class="kpi-label">Expenses</p>
+  </div>
+  <div class="kpi-divider"></div>
+  <div class="kpi-item">
+    <p class="kpi-value">{{formatCurrency .Data.NetAmount .Data.Currency}}</p>
+    <p class="kpi-label">Cash Flow</p>
+  </div>
+  <div class="kpi-divider"></div>
+  <div class="kpi-item">
+    <p class="kpi-value">{{if gt .Data.TotalIncome 0.0}}{{formatPercent (mul (div .Data.NetAmount .Data.TotalIncome) 100)}}{{else}}N/A{{end}}</p>
+    <p class="kpi-label">Savings Rate</p>
+  </div>
 </div>
-{{if .Data.RecentTransactions}}
-<div class="table-wrapper">
-    <table class="txn-table">
-        <thead>
-            <tr>
-                <th>When</th>
-                <th>Transaction</th>
-                <th>Category</th>
-                <th>Account</th>
-                <th class="amount-col">Amount</th>
-            </tr>
-        </thead>
-        <tbody>
-        {{range .Data.RecentTransactions}}
-            <tr class="txn-row">
-                <td class="txn-date">{{.DateFormatted}}</td>
-                <td><strong>{{.Title}}</strong></td>
-                <td>{{if .CategoryName}}<span class="badge category-badge">{{.CategoryName}}</span>{{else}}<span class="no-data">Uncategorized</span>{{end}}</td>
-                <td>{{.AccountName}}</td>
-                <td class="txn-amount {{amountClass .Amount}}">{{formatCurrency .Amount $.Data.Currency}}</td>
-            </tr>
+
+<!-- Two Column Grid -->
+<div class="content-grid">
+  <!-- Left: Recent Transactions -->
+  <div>
+    <div class="section-header">
+      <h2>Recent Transactions</h2>
+      <a href="/transactions" class="section-link">View all transactions →</a>
+    </div>
+    {{if .Data.RecentTransactions}}
+    {{range .Data.RecentTransactions}}
+    <div class="txn-row">
+      <span class="txn-dot {{amountClass .Amount}}"></span>
+      <span class="txn-desc">{{.Title}}</span>
+      {{if .CategoryName}}<span class="txn-badge badge">{{.CategoryName}}</span>{{end}}
+      <span class="txn-amount {{amountClass .Amount}}">{{formatCurrency .Amount $.Data.Currency}}</span>
+    </div>
+    {{end}}
+    {{else}}
+    <div class="empty-state">
+      <div class="empty-icon">+</div>
+      <p>No transactions yet</p>
+      <a href="/transactions" role="button" class="outline">Add your first transaction</a>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Right: Budgets + Chart -->
+  <div>
+    <div class="section-header">
+      <h2>Budgets</h2>
+    </div>
+    {{if .Data.BudgetStatus}}
+    {{range .Data.BudgetStatus}}
+    <div class="budget-item">
+      <div class="budget-label-row">
+        <span class="budget-cat">{{.Name}}</span>
+        <span class="budget-amounts">{{formatCurrency .Spent $.Data.Currency}} / {{formatCurrency .Amount $.Data.Currency}}</span>
+      </div>
+      <div class="progress-track">
+        <div class="progress-fill {{ternary (lt .SpentPct 70) "safe" (ternary (lt .SpentPct 90) "warning" "danger")}}" style="width:{{.SpentPct}}%"></div>
+      </div>
+    </div>
+    {{end}}
+    {{else}}
+    <div class="empty-state">
+      <p>No budgets set</p>
+      <a href="/budgets" role="button" class="outline">Set a budget</a>
+    </div>
+    {{end}}
+
+    <!-- Net Worth Chart -->
+    <div class="section-header" style="margin-top:1.5rem">
+      <h2>Net Worth</h2>
+    </div>
+    <div class="chart-container">
+      {{if gt $n 1}}
+      {{$paddingLeft := 40}}
+      {{$paddingRight := 20}}
+      {{$paddingTop := 20}}
+      {{$paddingBottom := 30}}
+      {{$chartW := 400}}
+      {{$chartH := 120}}
+      {{$areaW := sub (sub $chartW $paddingLeft) $paddingRight}}
+      {{$areaH := sub (sub $chartH $paddingTop) $paddingBottom}}
+      {{$step := div $areaW (sub $n 1)}}
+      {{$firstVal := (index $pts 0).Networth}}
+      {{$midY := add $paddingTop (div $areaH 2)}}
+      {{$last := index $pts (sub $n 1)}}
+      {{$lastX := add $paddingLeft (mul (sub $n 1) $step)}}
+      {{$lastY := sub $midY (div (sub $last.Networth $firstVal) 200)}}
+      {{$baseY := add $paddingTop $areaH}}
+      <svg viewBox="0 0 {{$chartW}} {{$chartH}}" class="chart-svg">
+        <line x1="{{$paddingLeft}}" y1="{{$paddingTop}}" x2="{{sub $chartW $paddingRight}}" y2="{{$paddingTop}}" stroke="var(--line)" stroke-width="0.5"/>
+        <line x1="{{$paddingLeft}}" y1="{{add $paddingTop (div $areaH 3)}}" x2="{{sub $chartW $paddingRight}}" y2="{{add $paddingTop (div $areaH 3)}}" stroke="var(--line)" stroke-width="0.5"/>
+        <line x1="{{$paddingLeft}}" y1="{{add $paddingTop (div (mul $areaH 2) 3)}}" x2="{{sub $chartW $paddingRight}}" y2="{{add $paddingTop (div (mul $areaH 2) 3)}}" stroke="var(--line)" stroke-width="0.5"/>
+        <line x1="{{$paddingLeft}}" y1="{{$baseY}}" x2="{{sub $chartW $paddingRight}}" y2="{{$baseY}}" stroke="var(--line)" stroke-width="0.5"/>
+        <path d="M{{$paddingLeft}} {{$baseY}} {{range $i, $p := $pts}}L{{add $paddingLeft (mul $i $step)}} {{sub $midY (div (sub $p.Networth $firstVal) 200)}} {{end}}L{{$lastX}} {{$baseY}}Z" fill="var(--accent-muted)"/>
+        <polyline fill="none" stroke="var(--accent)" stroke-width="1.5"
+          points="{{range $i, $p := $pts}}{{add $paddingLeft (mul $i $step)}},{{sub $midY (div (sub $p.Networth $firstVal) 200)}} {{end}}"/>
+        <circle cx="{{$lastX}}" cy="{{$lastY}}" r="3" fill="var(--accent)" stroke="var(--surface)" stroke-width="2"/>
+        <circle cx="{{$lastX}}" cy="{{$lastY}}" r="6" fill="none" stroke="var(--accent)" stroke-opacity="0.3" stroke-width="2"/>
+        {{range $i, $p := $pts}}
+        <text x="{{add $paddingLeft (mul $i $step)}}" y="{{sub $chartH 5}}" text-anchor="middle" fill="var(--text-muted)" font-size="9">{{$p.MonthLabel}}</text>
         {{end}}
-        </tbody>
-    </table>
-</div>
-{{else}}
-<div class="empty-state">
-    <div class="empty-icon">+</div>
-    <p>No transactions yet</p>
-    <a href="/transactions" role="button" class="outline">Add your first transaction</a>
-</div>
-{{end}}
-
-<!-- Budget Status -->
-{{if .Data.BudgetStatus}}
-<h2 class="section-title">Budget Status</h2>
-<div class="card-grid budget-grid">
-{{range .Data.BudgetStatus}}
-    <div class="dashboard-card">
-        <div class="card-label">{{.Name}}</div>
-        <div class="card-value">{{formatCurrency .Spent $.Data.Currency}} <small>of {{formatCurrency .Amount $.Data.Currency}}</small></div>
-        <div class="budget-bar">
-            <div class="budget-bar-fill {{ternary (lt .SpentPct 70) "safe" (ternary (lt .SpentPct 90) "warning" "danger")}}"
-                 style="width:{{.SpentPct}}%"></div>
-        </div>
-        <div class="card-sub">{{formatPercent .SpentPct}} spent · {{formatCurrency .Remaining $.Data.Currency}} remaining</div>
+      </svg>
+      {{else}}
+      <div class="empty-state">
+        <p>Not enough data yet</p>
+      </div>
+      {{end}}
     </div>
-{{end}}
-</div>
-{{end}}
-
-<!-- Net Worth Chart Placeholder -->
-<h2 class="section-title">Net Worth Trend</h2>
-<div class="chart-container">
-    <canvas id="networth-chart" height="200"></canvas>
+  </div>
 </div>
 
-<script>
-    (function() {
-        const canvas = document.getElementById('networth-chart');
-        if (!canvas) return;
-        const ctx = canvas.getContext('2d');
-        canvas.width = canvas.parentElement.clientWidth;
-
-        const data = [
-            {{range .Data.MonthlyNetworth}}
-            {month: "{{.MonthLabel}}", value: {{.Networth}} },
-            {{end}}
-        ];
-        if (data.length < 2) {
-            ctx.fillStyle = '#66736a';
-            ctx.fillText('Not enough data yet', 10, 30);
-            return;
-        }
-
-        const w = canvas.width - 40;
-        const h = canvas.height - 40;
-        const max = Math.max(...data.map(d => d.value));
-        const min = Math.min(...data.map(d => d.value), 0);
-        const range = max - min || 1;
-
-        ctx.strokeStyle = '#d7ff67';
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-
-        data.forEach((d, i) => {
-            const x = 20 + (i / (data.length - 1)) * w;
-            const y = h - ((d.value - min) / range) * h + 20;
-            if (i === 0) ctx.moveTo(x, y);
-            else ctx.lineTo(x, y);
-        });
-        ctx.stroke();
-
-        ctx.fillStyle = '#66736a';
-        ctx.font = '11px sans-serif';
-        data.forEach((d, i) => {
-            const x = 20 + (i / (data.length - 1)) * w;
-            ctx.fillText(d.month, x - 15, h + 35);
-        });
-    })();
-</script>
+<!-- Monthly Spending Heatmap -->
+<div class="section-header">
+  <h2>Spending Activity</h2>
+</div>
+<div class="heatmap">
+  <div class="heatmap-col">
+    <span class="cell-label">Mon</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+  <div class="heatmap-col">
+    <span class="cell-label">Tue</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+  <div class="heatmap-col">
+    <span class="cell-label">Wed</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+  <div class="heatmap-col">
+    <span class="cell-label">Thu</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+  <div class="heatmap-col">
+    <span class="cell-label">Fri</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+  <div class="heatmap-col">
+    <span class="cell-label">Sat</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+  <div class="heatmap-col">
+    <span class="cell-label">Sun</span>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+    <div class="heatmap-cell heatmap-level-0"></div>
+  </div>
+</div>
+<div class="heatmap-legend">
+  <span>Less</span>
+  <div class="heatmap-cell heatmap-level-0"></div>
+  <div class="heatmap-cell heatmap-level-1"></div>
+  <div class="heatmap-cell heatmap-level-2"></div>
+  <div class="heatmap-cell heatmap-level-3"></div>
+  <div class="heatmap-cell heatmap-level-4"></div>
+  <div class="heatmap-cell heatmap-level-5"></div>
+  <span>More</span>
+</div>
 
 {{end}}

--- a/web/templates/pages/export.html
+++ b/web/templates/pages/export.html
@@ -1,22 +1,21 @@
 {{define "content"}}
 
-<div class="export-options">
-    <a href="/export/csv" class="export-card" download>
+<div class="tile-grid">
+    <a href="/export/csv" class="tile">
         <h3>CSV Export</h3>
         <p>Download all your transactions as a CSV file</p>
-        <span class="export-arrow">↓</span>
     </a>
 
-    <div class="export-card">
+    <div class="tile" style="cursor:default">
         <h3>JSON Export</h3>
         <p>Full data export in JSON format</p>
-        <span class="badge">Coming soon</span>
+        <span class="badge" style="margin-top:8px">Coming soon</span>
     </div>
 
-    <div class="export-card">
+    <div class="tile" style="cursor:default">
         <h3>PDF Report</h3>
         <p>Download a formatted PDF summary</p>
-        <span class="badge">Coming soon</span>
+        <span class="badge" style="margin-top:8px">Coming soon</span>
     </div>
 </div>
 

--- a/web/templates/pages/import.html
+++ b/web/templates/pages/import.html
@@ -1,20 +1,21 @@
 {{define "content"}}
 
-<form method="post" action="/import" enctype="multipart/form-data" class="import-form">
+<form method="post" action="/import" enctype="multipart/form-data" style="display:grid;gap:16px">
     <div class="import-box">
         <label for="csv_file" class="file-label">
             <span class="file-icon">+</span>
             <span>Drop CSV file here or click to browse</span>
             <input type="file" id="csv_file" name="csv_file" accept=".csv" required
-                   onchange="this.parentElement.querySelector('span:last-child').textContent = this.files[0]?.name || 'Drop CSV file here or click to browse'">
+                   onchange="this.parentElement.querySelector('span:last-child').textContent = this.files[0]?.name || 'Drop CSV file here or click to browse'"
+                   style="position:absolute;opacity:0;pointer-events:none">
         </label>
     </div>
 
-    <div class="panel">
-        <h3 class="card-label">CSV Format</h3>
-        <p class="muted">Your CSV should have these columns:</p>
-        <code>Amount, Description, Date (YYYY-MM-DD), Type (income/expense/transfer), CategoryID (optional), AccountID (optional)</code>
-        <p class="muted">The first row is treated as a header and skipped.</p>
+    <div class="table-container" style="padding:14px">
+        <p class="field-label" style="margin:0 0 6px">CSV Format</p>
+        <p class="muted" style="margin:0 0 6px">Your CSV should have these columns:</p>
+        <code style="font-size:11px;color:var(--text-muted);display:block;margin-bottom:6px">Amount, Description, Date (YYYY-MM-DD), Type (income/expense/transfer), CategoryID (optional), AccountID (optional)</code>
+        <p class="muted" style="margin:0">The first row is treated as a header and skipped.</p>
     </div>
 
     <button type="submit" class="btn btn-primary">Import Transactions</button>

--- a/web/templates/pages/insurance.html
+++ b/web/templates/pages/insurance.html
@@ -1,58 +1,102 @@
 {{define "content"}}
 
-<details class="add-section">
-    <summary class="btn btn-primary">Add Policy</summary>
-    <form method="post" action="/insurance" class="inline-form">
-        <div class="form-grid">
-            <label>Name *<input type="text" name="name" required></label>
-            <label>Policy Type *
-                <select name="policy_type" required>
-                    <option value="">Choose policy type…</option>
-                    <option value="life">Life Insurance</option>
-                    <option value="health">Health Insurance</option>
-                    <option value="auto">Auto Insurance</option>
-                    <option value="home">Home Insurance</option>
-                    <option value="travel">Travel Insurance</option>
-                    <option value="term">Term Insurance</option>
-                    <option value="other">Other</option>
-                </select>
-            </label>
-            <label>Provider<input type="text" name="provider"></label>
-            <label>Currency<input type="text" name="currency" value="USD" maxlength="3"></label>
-            <label>Premium Amount<input type="number" name="premium_amount" step="0.01" min="0"></label>
-            <label>Premium Frequency
-                <select name="premium_frequency">
-                    <option value="monthly">Monthly</option>
-                    <option value="quarterly">Quarterly</option>
-                    <option value="yearly">Yearly</option>
-                    <option value="one_time">One Time</option>
-                </select>
-            </label>
-            <label>Coverage Amount<input type="number" name="coverage_amount" step="0.01" min="0"></label>
-            <label>Start Date<input type="date" name="start_date"></label>
-        </div>
-        <button type="submit" class="btn btn-primary">Create Policy</button>
-    </form>
-</details>
+<div style="display:flex;align-items:start;justify-content:flex-end;gap:16px;margin-bottom:16px">
+    <details class="add-section">
+        <summary class="btn btn-primary">+ Add Policy</summary>
+        <form method="post" action="/insurance" class="txn-form" style="position:absolute;right:0;top:100%;width:550px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
+            <div class="form-grid">
+                <div class="field">
+                    <label class="field-label">Name</label>
+                    <div class="input-wrap"><input type="text" name="name" required></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Policy Type</label>
+                    <div class="input-wrap">
+                        <select name="policy_type" required>
+                            <option value="">Choose…</option>
+                            <option value="life">Life Insurance</option>
+                            <option value="health">Health Insurance</option>
+                            <option value="auto">Auto Insurance</option>
+                            <option value="home">Home Insurance</option>
+                            <option value="travel">Travel Insurance</option>
+                            <option value="term">Term Insurance</option>
+                            <option value="other">Other</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Provider</label>
+                    <div class="input-wrap"><input type="text" name="provider"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Currency</label>
+                    <div class="input-wrap"><input type="text" name="currency" value="USD" maxlength="3"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Premium Amount</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="premium_amount" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Premium Frequency</label>
+                    <div class="input-wrap">
+                        <select name="premium_frequency">
+                            <option value="monthly">Monthly</option>
+                            <option value="quarterly">Quarterly</option>
+                            <option value="yearly">Yearly</option>
+                            <option value="one_time">One Time</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Coverage Amount</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="coverage_amount" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Start Date</label>
+                    <div class="input-wrap"><input type="date" name="start_date"></div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Policy</button>
+        </form>
+    </details>
+</div>
 
 {{if .Data}}
-<div class="table-wrapper"><table class="data-table">
-<thead><tr><th>Name</th><th>Type</th><th>Provider</th><th>Premium</th><th>Frequency</th><th>Coverage</th><th>Start</th><th>End</th></tr></thead>
-<tbody>
-{{range .Data}}
-<tr>
-    <td><strong>{{.Name}}</strong></td>
-    <td><span class="badge type-badge">{{.PolicyType}}</span></td>
-    <td>{{if .Provider}}{{.Provider}}{{else}}—{{end}}</td>
-    <td>{{formatCurrency .PremiumAmount .Currency}}</td>
-    <td>{{.PremiumFrequency}}</td>
-    <td>{{formatCurrency .CoverageAmount .Currency}}</td>
-    <td>{{.StartDate}}</td>
-    <td>{{if .EndDate}}{{.EndDate}}{{else}}—{{end}}</td>
-</tr>
+<div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Provider</th>
+                <th class="amount-col">Premium</th>
+                <th>Frequency</th>
+                <th class="amount-col">Coverage</th>
+                <th>Start</th>
+                <th>End</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Data}}
+            <tr>
+                <td><strong>{{.Name}}</strong></td>
+                <td><span class="badge">{{.PolicyType}}</span></td>
+                <td>{{if .Provider}}{{.Provider}}{{else}}<span class="no-data">—</span>{{end}}</td>
+                <td class="txn-amount">{{formatCurrency .PremiumAmount .Currency}}</td>
+                <td>{{.PremiumFrequency}}</td>
+                <td class="txn-amount">{{formatCurrency .CoverageAmount .Currency}}</td>
+                <td>{{.StartDate}}</td>
+                <td>{{if .EndDate}}{{.EndDate}}{{else}}<span class="no-data">—</span>{{end}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="empty-state">
+    <p>No insurance policies yet.</p>
+    <p>Add your first policy to track coverage.</p>
+</div>
 {{end}}
-</tbody>
-</table></div>
-{{else}}<div class="empty-state"><p>No insurance policies yet.</p></div>{{end}}
 
 {{end}}

--- a/web/templates/pages/investments.html
+++ b/web/templates/pages/investments.html
@@ -1,52 +1,96 @@
 {{define "content"}}
 
-<details class="add-section">
-    <summary class="btn btn-primary">Add Investment</summary>
-    <form method="post" action="/investments" class="inline-form">
-        <div class="form-grid">
-            <label>Name *<input type="text" name="name" required></label>
-            <label>Asset Type *
-                <select name="asset_type" required>
-                    <option value="">Choose asset type…</option>
-                    <option value="stock">Stock</option>
-                    <option value="mutual_fund">Mutual Fund</option>
-                    <option value="etf">ETF</option>
-                    <option value="bond">Bond</option>
-                    <option value="crypto">Crypto</option>
-                    <option value="real_estate">Real Estate</option>
-                    <option value="fd">Fixed Deposit</option>
-                    <option value="other">Other</option>
-                </select>
-            </label>
-            <label>Currency<input type="text" name="currency" value="USD" maxlength="3"></label>
-            <label>Quantity<input type="number" name="quantity" step="any" min="0"></label>
-            <label>Buy Price<input type="number" name="buy_price" step="any" min="0"></label>
-            <label>Current Price<input type="number" name="current_price" step="any" min="0"></label>
-            <label>Interest Rate %<input type="number" name="interest_rate" step="0.01" min="0"></label>
-            <label>Maturity Date<input type="date" name="maturity_date"></label>
-        </div>
-        <button type="submit" class="btn btn-primary">Create Investment</button>
-    </form>
-</details>
+<div style="display:flex;align-items:start;justify-content:flex-end;gap:16px;margin-bottom:16px">
+    <details class="add-section">
+        <summary class="btn btn-primary">+ Add Investment</summary>
+        <form method="post" action="/investments" class="txn-form" style="position:absolute;right:0;top:100%;width:550px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
+            <div class="form-grid">
+                <div class="field">
+                    <label class="field-label">Name</label>
+                    <div class="input-wrap"><input type="text" name="name" required></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Asset Type</label>
+                    <div class="input-wrap">
+                        <select name="asset_type" required>
+                            <option value="">Choose…</option>
+                            <option value="stock">Stock</option>
+                            <option value="mutual_fund">Mutual Fund</option>
+                            <option value="etf">ETF</option>
+                            <option value="bond">Bond</option>
+                            <option value="crypto">Crypto</option>
+                            <option value="real_estate">Real Estate</option>
+                            <option value="fd">Fixed Deposit</option>
+                            <option value="other">Other</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Currency</label>
+                    <div class="input-wrap"><input type="text" name="currency" value="USD" maxlength="3"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Quantity</label>
+                    <div class="input-wrap"><input type="number" name="quantity" step="any" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Buy Price</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="buy_price" step="any" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Current Price</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="current_price" step="any" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Interest Rate %</label>
+                    <div class="input-wrap"><input type="number" name="interest_rate" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Maturity Date</label>
+                    <div class="input-wrap"><input type="date" name="maturity_date"></div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Investment</button>
+        </form>
+    </details>
+</div>
 
 {{if .Data}}
-<div class="table-wrapper"><table class="data-table">
-<thead><tr><th>Name</th><th>Type</th><th>Qty</th><th>Buy</th><th>Current</th><th>Value</th><th>P/L %</th><th>Currency</th></tr></thead>
-<tbody>
-{{range .Data}}
-<tr>
-    <td><strong>{{.Name}}</strong>{{if .MaturityDate}} <small>(mat: {{.MaturityDate}})</small>{{end}}</td>
-    <td><span class="badge type-badge">{{.AssetType}}</span></td>
-    <td>{{printf "%.4g" .Quantity}}</td>
-    <td>{{printf "%.2f" .BuyPrice}}</td>
-    <td>{{printf "%.2f" .CurrentPrice}}</td>
-    <td>{{printf "%.2f" .CurrentValue}} {{.Currency}}</td>
-    <td class="{{if gt .GainLossPct 0.0}}positive{{else if lt .GainLossPct 0.0}}negative{{end}}">{{printf "%+.2f" .GainLossPct}}%</td>
-    <td>{{.Currency}}</td>
-</tr>
+<div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th class="amount-col">Qty</th>
+                <th class="amount-col">Buy</th>
+                <th class="amount-col">Current</th>
+                <th class="amount-col">Value</th>
+                <th class="amount-col">P/L %</th>
+                <th>Currency</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Data}}
+            <tr>
+                <td><strong>{{.Name}}</strong>{{if .MaturityDate}} <span class="no-data" style="font-size:11px">(mat: {{.MaturityDate}})</span>{{end}}</td>
+                <td><span class="badge">{{.AssetType}}</span></td>
+                <td class="txn-amount">{{printf "%.4g" .Quantity}}</td>
+                <td class="txn-amount">{{printf "%.2f" .BuyPrice}}</td>
+                <td class="txn-amount">{{printf "%.2f" .CurrentPrice}}</td>
+                <td class="txn-amount">{{printf "%.2f" .CurrentValue}} {{.Currency}}</td>
+                <td class="txn-amount {{if gt .GainLossPct 0.0}}positive{{else if lt .GainLossPct 0.0}}negative{{end}}">{{printf "%+.2f" .GainLossPct}}%</td>
+                <td>{{.Currency}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="empty-state">
+    <p>No investments yet.</p>
+    <p>Add your first investment to track performance.</p>
+</div>
 {{end}}
-</tbody>
-</table></div>
-{{else}}<div class="empty-state"><p>No investments yet.</p></div>{{end}}
 
 {{end}}

--- a/web/templates/pages/loans.html
+++ b/web/templates/pages/loans.html
@@ -1,53 +1,100 @@
 {{define "content"}}
 
-<details class="add-section">
-    <summary class="btn btn-primary">Add Loan</summary>
-    <form method="post" action="/loans" class="inline-form">
-        <div class="form-grid">
-            <label>Name *<input type="text" name="name" required></label>
-            <label>Loan Type *
-                <select name="loan_type" required>
-                    <option value="">Choose loan type…</option>
-                    <option value="personal">Personal Loan</option>
-                    <option value="home">Home Loan</option>
-                    <option value="auto">Auto Loan</option>
-                    <option value="education">Education</option>
-                    <option value="business">Business</option>
-                    <option value="credit_card_debt">Credit Card Debt</option>
-                    <option value="lent">Lent (given)</option>
-                    <option value="other">Other</option>
-                </select>
-            </label>
-            <label>Currency<input type="text" name="currency" value="USD" maxlength="3"></label>
-            <label>Principal<input type="number" name="principal" step="0.01" min="0"></label>
-            <label>Interest Rate %<input type="number" name="interest_rate" step="0.01" min="0"></label>
-            <label>Tenure (months)<input type="number" name="tenure_months" min="0"></label>
-            <label>EMI Amount<input type="number" name="emi_amount" step="0.01" min="0"></label>
-            <label>Outstanding Balance<input type="number" name="outstanding_balance" step="0.01" min="0"></label>
-            <label>Start Date<input type="date" name="start_date"></label>
-        </div>
-        <button type="submit" class="btn btn-primary">Create Loan</button>
-    </form>
-</details>
+<div style="display:flex;align-items:start;justify-content:flex-end;gap:16px;margin-bottom:16px">
+    <details class="add-section">
+        <summary class="btn btn-primary">+ Add Loan</summary>
+        <form method="post" action="/loans" class="txn-form" style="position:absolute;right:0;top:100%;width:550px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
+            <div class="form-grid">
+                <div class="field">
+                    <label class="field-label">Name</label>
+                    <div class="input-wrap"><input type="text" name="name" required></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Loan Type</label>
+                    <div class="input-wrap">
+                        <select name="loan_type" required>
+                            <option value="">Choose…</option>
+                            <option value="personal">Personal Loan</option>
+                            <option value="home">Home Loan</option>
+                            <option value="auto">Auto Loan</option>
+                            <option value="education">Education</option>
+                            <option value="business">Business</option>
+                            <option value="credit_card_debt">Credit Card Debt</option>
+                            <option value="lent">Lent (given)</option>
+                            <option value="other">Other</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Currency</label>
+                    <div class="input-wrap"><input type="text" name="currency" value="USD" maxlength="3"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Principal</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="principal" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Interest Rate %</label>
+                    <div class="input-wrap"><input type="number" name="interest_rate" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Tenure (months)</label>
+                    <div class="input-wrap"><input type="number" name="tenure_months" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">EMI Amount</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="emi_amount" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Outstanding Balance</label>
+                    <div class="input-wrap"><span class="input-deco">$</span><input type="number" name="outstanding_balance" step="0.01" min="0"></div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Start Date</label>
+                    <div class="input-wrap"><input type="date" name="start_date"></div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Loan</button>
+        </form>
+    </details>
+</div>
 
 {{if .Data}}
-<div class="table-wrapper"><table class="data-table">
-<thead><tr><th>Name</th><th>Type</th><th>Principal</th><th>Rate</th><th>Outstanding</th><th>EMI</th><th>Tenure</th><th>Start</th></tr></thead>
-<tbody>
-{{range .Data}}
-<tr>
-    <td><strong>{{.Name}}</strong></td>
-    <td><span class="badge type-badge">{{.LoanType}}</span></td>
-    <td>{{formatCurrency .Principal .Currency}}</td>
-    <td>{{printf "%.2f" .InterestRate}}%</td>
-    <td class="negative">{{formatCurrency .OutstandingBalance .Currency}}</td>
-    <td>{{if gt .EMI 0.0}}{{formatCurrency .EMI .Currency}}{{else}}—{{end}}</td>
-    <td>{{if gt .TenureMonths 0}}{{.TenureMonths}} mo{{else}}—{{end}}</td>
-    <td>{{.StartDate}}</td>
-</tr>
+<div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th class="amount-col">Principal</th>
+                <th class="amount-col">Rate</th>
+                <th class="amount-col">Outstanding</th>
+                <th class="amount-col">EMI</th>
+                <th>Tenure</th>
+                <th>Start</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Data}}
+            <tr>
+                <td><strong>{{.Name}}</strong></td>
+                <td><span class="badge">{{.LoanType}}</span></td>
+                <td class="txn-amount">{{formatCurrency .Principal .Currency}}</td>
+                <td class="txn-amount">{{printf "%.2f" .InterestRate}}%</td>
+                <td class="txn-amount negative">{{formatCurrency .OutstandingBalance .Currency}}</td>
+                <td class="txn-amount">{{if gt .EMI 0.0}}{{formatCurrency .EMI .Currency}}{{else}}<span class="no-data">—</span>{{end}}</td>
+                <td>{{if gt .TenureMonths 0}}{{.TenureMonths}} mo{{else}}<span class="no-data">—</span>{{end}}</td>
+                <td>{{.StartDate}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="empty-state">
+    <p>No loans yet.</p>
+    <p>Add your first loan to track repayment.</p>
+</div>
 {{end}}
-</tbody>
-</table></div>
-{{else}}<div class="empty-state"><p>No loans yet.</p></div>{{end}}
 
 {{end}}

--- a/web/templates/pages/login.html
+++ b/web/templates/pages/login.html
@@ -1,28 +1,33 @@
 {{define "content"}}
 <div class="auth-page" x-data="{ email: '', password: '' }">
     <div class="auth-card">
+        <span class="auth-logo">L</span>
         <h1>Welcome back</h1>
         <p class="auth-subtitle">Sign in to your Ledgerify account</p>
 
         {{if .Flashes}}
-        <div class="flashes">
+        <div class="flashes" style="width:100%">
             {{range .Flashes}}
-            <article class="flash flash-{{.Type}}">{{.Message}}</article>
+            <div class="flash flash-{{.Type}}">{{.Message}}</div>
             {{end}}
         </div>
         {{end}}
 
         <form hx-post="/login" hx-target="body" hx-push-url="false" method="POST">
-            <label>
-                Email
-                <input type="email" name="email" x-model="email" required
-                       placeholder="you@example.com" autocomplete="email">
-            </label>
-            <label>
-                Password
-                <input type="password" name="password" x-model="password" required
-                       placeholder="••••••••" autocomplete="current-password">
-            </label>
+            <div class="field">
+                <label class="field-label">Email</label>
+                <div class="input-wrap">
+                    <input type="email" name="email" x-model="email" required
+                           placeholder="you@example.com" autocomplete="email">
+                </div>
+            </div>
+            <div class="field">
+                <label class="field-label">Password</label>
+                <div class="input-wrap">
+                    <input type="password" name="password" x-model="password" required
+                           placeholder="••••••••" autocomplete="current-password">
+                </div>
+            </div>
             <button type="submit" class="btn btn-primary w-full">Sign in</button>
         </form>
 

--- a/web/templates/pages/register.html
+++ b/web/templates/pages/register.html
@@ -1,33 +1,40 @@
 {{define "content"}}
 <div class="auth-page" x-data="{ name: '', email: '', password: '' }">
     <div class="auth-card">
+        <span class="auth-logo">L</span>
         <h1>Create your account</h1>
         <p class="auth-subtitle">Start tracking your finances</p>
 
         {{if .Flashes}}
-        <div class="flashes">
+        <div class="flashes" style="width:100%">
             {{range .Flashes}}
-            <article class="flash flash-{{.Type}}">{{.Message}}</article>
+            <div class="flash flash-{{.Type}}">{{.Message}}</div>
             {{end}}
         </div>
         {{end}}
 
         <form hx-post="/register" hx-target="body" hx-push-url="false" method="POST">
-            <label>
-                Name
-                <input type="text" name="name" x-model="name" required
-                       placeholder="Your name">
-            </label>
-            <label>
-                Email
-                <input type="email" name="email" x-model="email" required
-                       placeholder="you@example.com" autocomplete="email">
-            </label>
-            <label>
-                Password
-                <input type="password" name="password" x-model="password" required
-                       placeholder="Min 6 characters" minlength="6" autocomplete="new-password">
-            </label>
+            <div class="field">
+                <label class="field-label">Name</label>
+                <div class="input-wrap">
+                    <input type="text" name="name" x-model="name" required
+                           placeholder="Your name">
+                </div>
+            </div>
+            <div class="field">
+                <label class="field-label">Email</label>
+                <div class="input-wrap">
+                    <input type="email" name="email" x-model="email" required
+                           placeholder="you@example.com" autocomplete="email">
+                </div>
+            </div>
+            <div class="field">
+                <label class="field-label">Password</label>
+                <div class="input-wrap">
+                    <input type="password" name="password" x-model="password" required
+                           placeholder="Min 6 characters" minlength="6" autocomplete="new-password">
+                </div>
+            </div>
             <button type="submit" class="btn btn-primary w-full">Create account</button>
         </form>
 

--- a/web/templates/pages/reports-budget.html
+++ b/web/templates/pages/reports-budget.html
@@ -1,6 +1,6 @@
 {{define "content"}}
 
-<p class="muted">Compare your budget targets with actual spending</p>
+<p class="muted" style="margin-bottom:16px">Compare your budget targets with actual spending</p>
 
 {{if .Data}}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
@@ -9,46 +9,60 @@
 </div>
 <script>
 const bvaData = JSON.parse({{.Data}});
-new Chart(document.getElementById('budgetChart'), {
-    type: 'bar',
-    data: {
-        labels: bvaData.labels,
-        datasets: [
-            {
-                label: 'Budget',
-                data: bvaData.budget,
-                backgroundColor: '#30443a',
-                borderColor: '#30443a',
-                borderWidth: 1
+const ctxBV = document.getElementById('budgetChart');
+if (ctxBV) {
+    new Chart(ctxBV, {
+        type: 'bar',
+        data: {
+            labels: bvaData.labels,
+            datasets: [
+                {
+                    label: 'Budget',
+                    data: bvaData.budget,
+                    backgroundColor: 'rgba(194,90,62,0.7)',
+                    borderColor: '#c25a3e',
+                    borderWidth: 1,
+                    borderRadius: 3
+                },
+                {
+                    label: 'Actual',
+                    data: bvaData.actual,
+                    backgroundColor: 'rgba(183,121,31,0.7)',
+                    borderColor: '#b7791f',
+                    borderWidth: 1,
+                    borderRadius: 3
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'top', labels: { font: { size: 12 }, boxWidth: 12, padding: 12 } },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => `${ctx.dataset.label}: ${parseFloat(ctx.raw).toFixed(2)}`
+                    }
+                }
             },
-            {
-                label: 'Actual',
-                data: bvaData.actual,
-                backgroundColor: '#b7791f',
-                borderColor: '#b7791f',
-                borderWidth: 1
-            }
-        ]
-    },
-    options: {
-        responsive: true,
-        plugins: {
-            legend: { position: 'top' },
-            tooltip: {
-                callbacks: {
-                    label: ctx => `${ctx.dataset.label}: ${parseFloat(ctx.raw).toFixed(2)}`
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { callback: v => v.toFixed(0) },
+                    grid: { color: 'rgba(0,0,0,0.06)' }
+                },
+                x: {
+                    grid: { display: false }
                 }
             }
-        },
-        scales: {
-            y: {
-                beginAtZero: true,
-                ticks: { callback: v => v.toFixed(0) }
-            }
         }
-    }
-});
+    });
+}
 </script>
-{{else}}<p class="empty-state">No budgets found. Create budgets to compare against actual spending.</p>{{end}}
+{{else}}
+<div class="empty-state">
+    <p>No budgets found.</p>
+    <p>Create budgets to compare against actual spending.</p>
+</div>
+{{end}}
 
 {{end}}

--- a/web/templates/pages/reports-cashflow.html
+++ b/web/templates/pages/reports-cashflow.html
@@ -1,6 +1,6 @@
 {{define "content"}}
 
-<p class="muted">Monthly income vs expenses over the last 12 months</p>
+<p class="muted" style="margin-bottom:16px">Monthly income vs expenses over the last 12 months</p>
 
 {{if .Data}}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
@@ -9,46 +9,60 @@
 </div>
 <script>
 const cfData = JSON.parse({{.Data}});
-new Chart(document.getElementById('cashFlowChart'), {
-    type: 'bar',
-    data: {
-        labels: cfData.labels,
-        datasets: [
-            {
-                label: 'Income',
-                data: cfData.income,
-                backgroundColor: '#16835a',
-                borderColor: '#16835a',
-                borderWidth: 1
+const ctxCF = document.getElementById('cashFlowChart');
+if (ctxCF) {
+    new Chart(ctxCF, {
+        type: 'bar',
+        data: {
+            labels: cfData.labels,
+            datasets: [
+                {
+                    label: 'Income',
+                    data: cfData.income,
+                    backgroundColor: 'rgba(22,131,90,0.8)',
+                    borderColor: '#16835a',
+                    borderWidth: 1,
+                    borderRadius: 3
+                },
+                {
+                    label: 'Expenses',
+                    data: cfData.expense,
+                    backgroundColor: 'rgba(189,62,62,0.8)',
+                    borderColor: '#bd3e3e',
+                    borderWidth: 1,
+                    borderRadius: 3
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'top', labels: { font: { size: 12 }, boxWidth: 12, padding: 12 } },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => `${ctx.dataset.label}: ${parseFloat(ctx.raw).toFixed(2)}`
+                    }
+                }
             },
-            {
-                label: 'Expenses',
-                data: cfData.expense,
-                backgroundColor: '#bd3e3e',
-                borderColor: '#bd3e3e',
-                borderWidth: 1
-            }
-        ]
-    },
-    options: {
-        responsive: true,
-        plugins: {
-            legend: { position: 'top' },
-            tooltip: {
-                callbacks: {
-                    label: ctx => `${ctx.dataset.label}: ${parseFloat(ctx.raw).toFixed(2)}`
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { callback: v => v.toFixed(0) },
+                    grid: { color: 'rgba(0,0,0,0.06)' }
+                },
+                x: {
+                    grid: { display: false }
                 }
             }
-        },
-        scales: {
-            y: {
-                beginAtZero: true,
-                ticks: { callback: v => v.toFixed(0) }
-            }
         }
-    }
-});
+    });
+}
 </script>
-{{else}}<p class="empty-state">No data available. Add transactions to see your cash flow.</p>{{end}}
+{{else}}
+<div class="empty-state">
+    <p>No data available.</p>
+    <p>Add transactions to see your cash flow.</p>
+</div>
+{{end}}
 
 {{end}}

--- a/web/templates/pages/reports-category.html
+++ b/web/templates/pages/reports-category.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 
 {{if .Data}}
-<p class="muted">Spending by category — {{.Data.Period}}</p>
+<p class="muted" style="margin-bottom:16px">Spending by category — {{.Data.Period}}</p>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <div class="chart-container">
@@ -10,34 +10,42 @@
 
 <script>
 const catData = JSON.parse({{.Data.chartData}});
-new Chart(document.getElementById('categoryChart'), {
-    type: 'doughnut',
-    data: {
-        labels: catData.labels,
-        datasets: [{
-            data: catData.amounts,
-            backgroundColor: catData.colors,
-            borderColor: 'var(--surface)',
-            borderWidth: 2
-        }]
-    },
-    options: {
-        responsive: true,
-        plugins: {
-            legend: { position: 'right' },
-            tooltip: {
-                callbacks: {
-                    label: ctx => {
-                        const total = ctx.dataset.data.reduce((a,b) => a+b, 0);
-                        const pct = total > 0 ? ((ctx.raw/total)*100).toFixed(1) : 0;
-                        return ` ${ctx.label}: ${ctx.raw.toFixed(2)} (${pct}%)`;
+const ctxCat = document.getElementById('categoryChart');
+if (ctxCat) {
+    new Chart(ctxCat, {
+        type: 'doughnut',
+        data: {
+            labels: catData.labels,
+            datasets: [{
+                data: catData.amounts,
+                backgroundColor: catData.colors || ['#c25a3e','#2563eb','#16835a','#b7791f','#7a7570','#8b5cf6'],
+                borderColor: 'var(--surface)',
+                borderWidth: 2
+            }]
+        },
+        options: {
+            responsive: true,
+            cutout: '60%',
+            plugins: {
+                legend: { position: 'right', labels: { font: { size: 11 }, boxWidth: 12, padding: 12 } },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => {
+                            const total = ctx.dataset.data.reduce((a,b) => a+b, 0);
+                            const pct = total > 0 ? ((ctx.raw/total)*100).toFixed(1) : 0;
+                            return ` ${ctx.label}: ${ctx.raw.toFixed(2)} (${pct}%)`;
+                        }
                     }
                 }
             }
         }
-    }
-});
+    });
+}
 </script>
-{{else}}<p class="empty-state">No spending data for this period.</p>{{end}}
+{{else}}
+<div class="empty-state">
+    <p>No spending data for this period.</p>
+</div>
+{{end}}
 
 {{end}}

--- a/web/templates/pages/reports-debt.html
+++ b/web/templates/pages/reports-debt.html
@@ -1,15 +1,10 @@
 {{define "content"}}
 
-<p class="muted">Coming soon — loan repayment projections and payoff strategies.</p>
+<p class="muted" style="margin-bottom:16px">Loan repayment progress and projections</p>
 
-<div class="coming-soon">
-    <p>This report will show:</p>
-    <ul>
-        <li>Total debt over time</li>
-        <li>Remaining balances by loan</li>
-        <li>Projected payoff dates</li>
-        <li>Interest savings from extra payments</li>
-    </ul>
+<div class="empty-state">
+    <p>Coming soon</p>
+    <p style="font-size:11px">Debt payoff projections and payoff strategies will appear here.</p>
 </div>
 
 {{end}}

--- a/web/templates/pages/reports-index.html
+++ b/web/templates/pages/reports-index.html
@@ -1,35 +1,29 @@
 {{define "content"}}
 
-<div class="report-grid">
-    <a href="/reports/cash-flow" class="report-card">
+<div class="tile-grid">
+    <a href="/reports/cash-flow" class="tile">
         <h3>Cash Flow</h3>
         <p>Monthly income vs expenses over the past year</p>
-        <span class="report-arrow">→</span>
     </a>
-    <a href="/reports/category-breakdown" class="report-card">
+    <a href="/reports/category-breakdown" class="tile">
         <h3>Category Breakdown</h3>
         <p>Where your money goes by category</p>
-        <span class="report-arrow">→</span>
     </a>
-    <a href="/reports/budget-vs-actual" class="report-card">
+    <a href="/reports/budget-vs-actual" class="tile">
         <h3>Budget vs Actual</h3>
         <p>Compare budget targets with actual spending</p>
-        <span class="report-arrow">→</span>
     </a>
-    <a href="/reports/networth" class="report-card">
+    <a href="/reports/networth" class="tile">
         <h3>Net Worth</h3>
         <p>Track your net worth over time</p>
-        <span class="report-arrow">→</span>
     </a>
-    <a href="/reports/investment-returns" class="report-card">
+    <a href="/reports/investment-returns" class="tile">
         <h3>Investment Returns</h3>
         <p>Portfolio performance and P/L tracking</p>
-        <span class="report-arrow">→</span>
     </a>
-    <a href="/reports/debt-payoff" class="report-card">
+    <a href="/reports/debt-payoff" class="tile">
         <h3>Debt Payoff</h3>
         <p>Loan repayment progress and projections</p>
-        <span class="report-arrow">→</span>
     </a>
 </div>
 

--- a/web/templates/pages/reports-investments.html
+++ b/web/templates/pages/reports-investments.html
@@ -1,15 +1,10 @@
 {{define "content"}}
 
-<p class="muted">Coming soon — portfolio performance tracking and P/L analytics.</p>
+<p class="muted" style="margin-bottom:16px">Portfolio performance tracking and P/L analytics</p>
 
-<div class="coming-soon">
-    <p>This report will show:</p>
-    <ul>
-        <li>Portfolio value over time</li>
-        <li>Asset allocation breakdown</li>
-        <li>Individual investment P/L</li>
-        <li>Return vs benchmark comparison</li>
-    </ul>
+<div class="empty-state">
+    <p>Coming soon</p>
+    <p style="font-size:11px">Portfolio value over time, asset allocation, and return comparisons will appear here.</p>
 </div>
 
 {{end}}

--- a/web/templates/pages/reports-networth.html
+++ b/web/templates/pages/reports-networth.html
@@ -1,6 +1,6 @@
 {{define "content"}}
 
-<p class="muted">Track your net worth over time</p>
+<p class="muted" style="margin-bottom:16px">Track your net worth over time</p>
 
 {{if .Data}}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
@@ -9,39 +9,52 @@
 </div>
 <script>
 const nwData = JSON.parse({{.Data}});
-new Chart(document.getElementById('networthChart'), {
-    type: 'line',
-    data: {
-        labels: nwData.labels,
-        datasets: [{
-            label: 'Net Worth',
-            data: nwData.balance,
-            borderColor: '#d7ff67',
-            backgroundColor: 'rgba(215, 255, 103, 0.1)',
-            fill: true,
-            tension: 0.3,
-            pointRadius: 3,
-            pointHoverRadius: 6
-        }]
-    },
-    options: {
-        responsive: true,
-        plugins: {
-            legend: { display: false },
-            tooltip: {
-                callbacks: {
-                    label: ctx => `Net Worth: ${parseFloat(ctx.raw).toFixed(2)}`
+const ctxNW = document.getElementById('networthChart');
+if (ctxNW) {
+    new Chart(ctxNW, {
+        type: 'line',
+        data: {
+            labels: nwData.labels,
+            datasets: [{
+                label: 'Net Worth',
+                data: nwData.balance,
+                borderColor: '#c25a3e',
+                backgroundColor: 'rgba(194,90,62,0.08)',
+                fill: true,
+                tension: 0.3,
+                pointRadius: 3,
+                pointBackgroundColor: '#c25a3e',
+                pointHoverRadius: 6
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => `Net Worth: ${parseFloat(ctx.raw).toFixed(2)}`
+                    }
+                }
+            },
+            scales: {
+                y: {
+                    ticks: { callback: v => v.toFixed(0) },
+                    grid: { color: 'rgba(0,0,0,0.06)' }
+                },
+                x: {
+                    grid: { display: false }
                 }
             }
-        },
-        scales: {
-            y: {
-                ticks: { callback: v => v.toFixed(0) }
-            }
         }
-    }
-});
+    });
+}
 </script>
-{{else}}<p class="empty-state">No net worth data yet. Add accounts and transactions to start tracking.</p>{{end}}
+{{else}}
+<div class="empty-state">
+    <p>No net worth data yet.</p>
+    <p>Add accounts and transactions to start tracking.</p>
+</div>
+{{end}}
 
 {{end}}

--- a/web/templates/pages/settings-categories.html
+++ b/web/templates/pages/settings-categories.html
@@ -1,64 +1,72 @@
 {{define "content"}}
 
-<details class="add-section">
-    <summary class="btn btn-primary">Add Category</summary>
-    <form method="post" action="/settings/categories" class="inline-form">
-        <div class="form-grid">
-            <label>
-                Name
-                <input type="text" name="name" required placeholder="Groceries, Rent, etc.">
-            </label>
-            <label>
-                Color
-                <input type="color" name="color" value="#6366f1">
-            </label>
-            <label>
-                Type
-                <select name="type">
-                    <option value="expense">Expense</option>
-                    <option value="income">Income</option>
-                    <option value="both">Both</option>
-                </select>
-            </label>
-        </div>
-        <button type="submit" class="btn btn-primary">Create Category</button>
-    </form>
-</details>
+<div style="display:flex;align-items:start;justify-content:space-between;gap:16px;margin-bottom:16px;flex-wrap:wrap">
+    <a href="/settings" class="btn btn-ghost btn-sm">← Back</a>
+    <details class="add-section" style="flex-shrink:0">
+        <summary class="btn btn-primary">+ Add Category</summary>
+        <form method="post" action="/settings/categories" class="txn-form" style="position:absolute;right:0;top:100%;width:400px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
+            <div class="form-grid">
+                <div class="field">
+                    <label class="field-label">Name</label>
+                    <div class="input-wrap">
+                        <input type="text" name="name" required placeholder="Groceries, Rent, etc.">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Color</label>
+                    <div class="input-wrap">
+                        <input type="color" name="color" value="#6366f1" style="height:32px;padding:2px">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Type</label>
+                    <div class="input-wrap">
+                        <select name="type">
+                            <option value="expense">Expense</option>
+                            <option value="income">Income</option>
+                            <option value="both">Both</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Category</button>
+        </form>
+    </details>
+</div>
 
 {{if .Data}}
-<div class="table-wrapper">
-<table class="table-striped">
-    <thead>
-        <tr>
-            <th>Color</th>
-            <th>Name</th>
-            <th>Type</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-    {{range .Data}}
-        <tr>
-            <td><span class="color-swatch" style="background: {{.Color.String}}"></span></td>
-            <td>{{.Name}}</td>
-            <td><span class="badge type-badge">{{.Type}}</span></td>
-            <td>
-                <form method="post" action="/settings/categories/{{.ID.UUID}}/delete"
-                      onsubmit="return confirm('Delete {{.Name}}?')">
-                    <button type="submit" class="btn-icon danger" aria-label="Delete {{.Name}}"><span aria-hidden="true">×</span></button>
-                </form>
-            </td>
-        </tr>
-    {{end}}
-    </tbody>
-</table>
+<div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Color</th>
+                <th>Name</th>
+                <th>Type</th>
+                <th class="action-col"></th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Data}}
+            <tr>
+                <td><span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:{{.Color.String}};border:1px solid var(--line);vertical-align:middle"></span></td>
+                <td>{{.Name}}</td>
+                <td><span class="badge">{{.Type}}</span></td>
+                <td class="action-col">
+                    <form method="post" action="/settings/categories/{{.ID.UUID}}/delete"
+                          onsubmit="return confirm('Delete {{.Name}}?')">
+                        <button type="submit" class="btn-icon danger" aria-label="Delete {{.Name}}">×</button>
+                    </form>
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
 </div>
 {{else}}
 <div class="empty-state">
-    <p>No categories yet. Create one to start categorizing transactions.</p>
+    <p>No categories yet.</p>
+    <p>Create one to start categorizing transactions.</p>
 </div>
 {{end}}
-
-<a href="/settings" class="back-link">← Back to Settings</a>
 
 {{end}}

--- a/web/templates/pages/settings.html
+++ b/web/templates/pages/settings.html
@@ -1,37 +1,26 @@
 {{define "content"}}
 
-<div class="settings-grid">
-    <a href="/settings/categories" class="settings-card">
+<div class="tile-grid">
+    <a href="/settings/categories" class="tile">
         <h3>Categories</h3>
         <p>Manage your transaction categories</p>
-        <span class="settings-arrow">→</span>
     </a>
-    <a href="/settings/currencies" class="settings-card">
+    <a href="/settings/currencies" class="tile">
         <h3>Currencies</h3>
         <p>Manage supported currencies</p>
-        <span class="settings-arrow">→</span>
     </a>
-    <a href="/settings/profile" class="settings-card">
+    <a href="/settings/profile" class="tile">
         <h3>Profile</h3>
         <p>Update email, name, password</p>
-        <span class="settings-arrow">→</span>
     </a>
-</div>
-
-<div class="settings-section settings-section--top">
-    <h3 class="section-title">Data Management</h3>
-    <div class="settings-grid">
-        <a href="/import" class="settings-card">
-            <h3>Import</h3>
-            <p>Import transactions from CSV</p>
-            <span class="settings-arrow">→</span>
-        </a>
-        <a href="/export" class="settings-card">
-            <h3>Export</h3>
-            <p>Download your data as CSV</p>
-            <span class="settings-arrow">→</span>
-        </a>
-    </div>
+    <a href="/import" class="tile">
+        <h3>Import</h3>
+        <p>Import transactions from CSV</p>
+    </a>
+    <a href="/export" class="tile">
+        <h3>Export</h3>
+        <p>Download your data as CSV</p>
+    </a>
 </div>
 
 {{end}}

--- a/web/templates/pages/transactions.html
+++ b/web/templates/pages/transactions.html
@@ -1,88 +1,118 @@
 {{define "content"}}
 
-<!-- Filters Bar -->
-<div class="filters-bar">
-    <form method="get" action="/transactions" class="filters-form">
-        <div class="filter-row">
-            <select name="type" onchange="this.form.submit()">
-                <option value="" {{if eq .Data.Filters.Type ""}}selected{{end}}>All Types</option>
-                <option value="income" {{if eq .Data.Filters.Type "income"}}selected{{end}}>Income</option>
-                <option value="expense" {{if eq .Data.Filters.Type "expense"}}selected{{end}}>Expense</option>
-            </select>
-
-            <select name="account_id" onchange="this.form.submit()">
-                <option value="">All Accounts</option>
-                {{range .Data.Accounts}}
-                <option value="{{.ID}}" {{if eq $.Data.Filters.AccountID .ID}}selected{{end}}>{{.Name}}</option>
-                {{end}}
-            </select>
-
-            <select name="category_id" onchange="this.form.submit()">
-                <option value="">All Categories</option>
-                {{range .Data.Categories}}
-                <option value="{{.ID}}" {{if eq $.Data.Filters.CategoryID .ID}}selected{{end}}>{{.Name}}</option>
-                {{end}}
-            </select>
-
-            <input type="date" name="from_date" value="{{.Data.Filters.FromDate}}" onchange="this.form.submit()">
-            <input type="date" name="to_date" value="{{.Data.Filters.ToDate}}" onchange="this.form.submit()">
-
-            <input type="search" name="search" value="{{.Data.Filters.Search}}" placeholder="Search…">
-        </div>
-        <div class="filter-actions">
-            <button type="submit" class="btn btn-primary btn-sm">Filter</button>
-            <a href="/transactions" class="btn btn-outline btn-sm">Clear</a>
-        </div>
-    </form>
+<!-- Filter Chips Row -->
+<div class="chip-group" style="margin-bottom:16px">
+    <a href="/transactions" class="chip {{if eq .Data.Filters.Type ""}}chip-active{{end}}">All</a>
+    <a href="/transactions?type=income" class="chip {{if eq .Data.Filters.Type "income"}}chip-active{{end}}">Income</a>
+    <a href="/transactions?type=expense" class="chip {{if eq .Data.Filters.Type "expense"}}chip-active{{end}}">Expenses</a>
 </div>
 
-<!-- Add Transaction Form -->
-<div class="add-txn-section">
-    <details class="add-section">
-        <summary class="btn btn-primary">Add Transaction</summary>
-        <form method="post" action="/transactions" class="txn-form">
+<!-- Filters + Add Toggle -->
+<div style="display:flex;align-items:start;justify-content:space-between;gap:16px;margin-bottom:16px;flex-wrap:wrap">
+    <form method="get" action="/transactions" style="display:flex;flex-wrap:wrap;gap:8px;align-items:end;flex:1">
+        <div class="field" style="flex:1;min-width:160px">
+            <label class="field-label">Search</label>
+            <div class="input-wrap">
+                <input type="search" name="search" value="{{.Data.Filters.Search}}" placeholder="Search transactions…">
+            </div>
+        </div>
+        <div class="field" style="min-width:120px">
+            <label class="field-label">Account</label>
+            <div class="input-wrap">
+                <select name="account_id" onchange="this.form.submit()">
+                    <option value="">All Accounts</option>
+                    {{range .Data.Accounts}}
+                    <option value="{{.ID}}" {{if eq $.Data.Filters.AccountID .ID}}selected{{end}}>{{.Name}}</option>
+                    {{end}}
+                </select>
+            </div>
+        </div>
+        <div class="field" style="min-width:120px">
+            <label class="field-label">Category</label>
+            <div class="input-wrap">
+                <select name="category_id" onchange="this.form.submit()">
+                    <option value="">All Categories</option>
+                    {{range .Data.Categories}}
+                    <option value="{{.ID}}" {{if eq $.Data.Filters.CategoryID .ID}}selected{{end}}>{{.Name}}</option>
+                    {{end}}
+                </select>
+            </div>
+        </div>
+        <div class="field" style="min-width:130px">
+            <label class="field-label">From</label>
+            <div class="input-wrap">
+                <input type="date" name="from_date" value="{{.Data.Filters.FromDate}}" onchange="this.form.submit()">
+            </div>
+        </div>
+        <div class="field" style="min-width:130px">
+            <label class="field-label">To</label>
+            <div class="input-wrap">
+                <input type="date" name="to_date" value="{{.Data.Filters.ToDate}}" onchange="this.form.submit()">
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary btn-sm" style="margin-bottom:0">Apply</button>
+        <a href="/transactions" class="btn btn-secondary btn-sm" style="margin-bottom:0">Clear</a>
+    </form>
+    <details class="add-section" style="flex-shrink:0">
+        <summary class="btn btn-primary">+ Add</summary>
+        <form method="post" action="/transactions" class="txn-form" style="position:absolute;right:0;top:100%;width:500px;max-width:90vw;z-index:50;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);padding:16px;margin-top:8px">
             <div class="form-grid">
-                <label>
-                    Type *
-                    <select name="type" required>
-                        <option value="income">Income</option>
-                        <option value="expense" selected>Expense</option>
-                    </select>
-                </label>
-                <label>
-                    Account *
-                    <select name="account_id" required>
-                        <option value="">Choose account…
-                        {{range .Data.Accounts}}
-                        <option value="{{.ID}}">{{.Name}} ({{.Currency}})</option>
-                        {{end}}
-                    </select>
-                </label>
-                <label>
-                    Amount *
-                    <input type="number" name="amount" step="0.01" min="0.01" required placeholder="0.00">
-                </label>
-                <label>
-                    Currency
-                    <input type="text" name="currency" value="USD" maxlength="3">
-                </label>
-                <label>
-                    Category
-                    <select name="category_id">
-                        <option value="">Uncategorized</option>
-                        {{range .Data.Categories}}
-                        <option value="{{.ID}}">{{.Name}}</option>
-                        {{end}}
-                    </select>
-                </label>
-                <label>
-                    Date *
-                    <input type="date" name="date" required value="{{(now).Format "2006-01-02"}}">
-                </label>
-                <label class="form-full">
-                    Title
-                    <input type="text" name="title" placeholder="e.g. Weekly groceries">
-                </label>
+                <div class="field">
+                    <label class="field-label">Type</label>
+                    <div class="input-wrap">
+                        <select name="type" required>
+                            <option value="expense" selected>Expense</option>
+                            <option value="income">Income</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Account</label>
+                    <div class="input-wrap">
+                        <select name="account_id" required>
+                            <option value="">Choose…
+                            {{range .Data.Accounts}}
+                            <option value="{{.ID}}">{{.Name}} ({{.Currency}})</option>
+                            {{end}}
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Amount</label>
+                    <div class="input-wrap">
+                        <span class="input-deco">$</span>
+                        <input type="number" name="amount" step="0.01" min="0.01" required placeholder="0.00">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Currency</label>
+                    <div class="input-wrap">
+                        <input type="text" name="currency" value="USD" maxlength="3">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Category</label>
+                    <div class="input-wrap">
+                        <select name="category_id">
+                            <option value="">Uncategorized</option>
+                            {{range .Data.Categories}}
+                            <option value="{{.ID}}">{{.Name}}</option>
+                            {{end}}
+                        </select>
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="field-label">Date</label>
+                    <div class="input-wrap">
+                        <input type="date" name="date" required value="{{(now).Format "2006-01-02"}}">
+                    </div>
+                </div>
+                <div class="field form-full">
+                    <label class="field-label">Title</label>
+                    <div class="input-wrap">
+                        <input type="text" name="title" placeholder="e.g. Weekly groceries">
+                    </div>
+                </div>
             </div>
             <button type="submit" class="btn btn-primary">Save Transaction</button>
         </form>
@@ -91,8 +121,8 @@
 
 <!-- Transactions Table -->
 {{if .Data.Transactions}}
-<div class="table-wrapper">
-    <table class="txn-table">
+<div class="table-container">
+    <table>
         <thead>
             <tr>
                 <th>Date</th>
@@ -106,13 +136,22 @@
         <tbody>
             {{range .Data.Transactions}}
             <tr class="txn-row txn-{{.Type}}">
-                <td class="txn-date">
-                    <span class="date-display">{{.DateFormatted}}</span>
+                <td class="txn-date">{{.DateFormatted}}</td>
+                <td>
+                    <div class="txn-title">
+                        <span style="display:flex;align-items:center;gap:6px">
+                            <span class="txn-dot {{.Type}}"></span>
+                            <strong>{{.Title}}</strong>
+                        </span>
+                        <span class="txn-kind">{{.Type}}</span>
+                    </div>
                 </td>
-                <td class="txn-title"><strong>{{.Title}}</strong><span class="txn-kind">{{.Type}}</span></td>
                 <td>
                     {{if .CategoryName}}
-                    <span class="badge category-badge" style="--cat-color: {{defaultStr .CategoryColor "#6b7280"}}">{{.CategoryName}}</span>
+                    <span class="badge category-badge" style="--cat-color: {{defaultStr .CategoryColor "#6b7280"}}">
+                        <span class="badge-dot" style="background:{{defaultStr .CategoryColor "#6b7280"}}"></span>
+                        {{.CategoryName}}
+                    </span>
                     {{else}}
                     <span class="no-data">Uncategorized</span>
                     {{end}}
@@ -124,7 +163,7 @@
                 <td class="action-col">
                     <form method="post" action="/transactions/delete" onsubmit="return confirm('Delete this transaction?')">
                         <input type="hidden" name="id" value="{{.ID}}">
-                        <button type="submit" class="btn-icon danger" aria-label="Delete transaction"><span aria-hidden="true">×</span></button>
+                        <button type="submit" class="btn-icon danger" aria-label="Delete transaction">×</button>
                     </form>
                 </td>
             </tr>
@@ -136,7 +175,9 @@
 <!-- Pagination -->
 <div class="pagination">
     {{if .Data.HasMore}}
-    <a href="?page={{add .Data.Filters.Page 1}}&type={{.Data.Filters.Type}}&account_id={{.Data.Filters.AccountID}}&category_id={{.Data.Filters.CategoryID}}&from_date={{.Data.Filters.FromDate}}&to_date={{.Data.Filters.ToDate}}&search={{.Data.Filters.Search}}" class="btn btn-outline">Load More</a>
+    <a href="?page={{add .Data.Filters.Page 1}}&type={{.Data.Filters.Type}}&account_id={{.Data.Filters.AccountID}}&category_id={{.Data.Filters.CategoryID}}&from_date={{.Data.Filters.FromDate}}&to_date={{.Data.Filters.ToDate}}&search={{.Data.Filters.Search}}" class="btn btn-secondary btn-sm">Load More</a>
+    {{else}}
+    <span></span>
     {{end}}
     <span class="txn-count">{{.Data.Count}} transactions</span>
 </div>

--- a/web/templates/partials/nav.html
+++ b/web/templates/partials/nav.html
@@ -1,35 +1,61 @@
 {{define "nav.html"}}
-<nav class="sidebar" x-data="{ mobileOpen: false }" aria-label="Primary">
-    <div class="sidebar-top">
-        <a href="/dashboard" class="brand-link" aria-label="Ledgerify dashboard">
-            <span class="brand-mark">L</span>
-            <span class="brand-name">Ledgerify</span>
+<nav class="sidebar" aria-label="Primary">
+    <a href="/dashboard" class="brand-link" aria-label="Ledgerify dashboard">
+        <span class="brand-mark">L</span>
+        <span class="brand-name">Ledgerify</span>
+    </a>
+
+    <div class="sidebar-links">
+        <a href="/dashboard" class="nav-link{{if eqStr .CurrentPath "/dashboard"}} active{{end}}" title="Dashboard">
+            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="13" y="13" width="8" height="8" rx="1"/></svg>
+            <span>Dashboard</span>
         </a>
-        <button class="mobile-toggle" @click="mobileOpen = !mobileOpen" aria-label="Toggle menu">
-            <span x-show="!mobileOpen">Menu</span>
-            <span x-show="mobileOpen">Close</span>
-        </button>
-    </div>
-
-    <div class="sidebar-links" x-bind:class="mobileOpen ? 'open' : ''">
-        <a href="/dashboard" class="nav-link{{if eqStr .CurrentPath "/dashboard"}} active{{end}}"><span class="nav-key">D</span><span>Dashboard</span></a>
-        <a href="/transactions" class="nav-link{{if hasPrefix .CurrentPath "/transactions"}} active{{end}}"><span class="nav-key">T</span><span>Transactions</span></a>
-        <a href="/accounts" class="nav-link{{if hasPrefix .CurrentPath "/accounts"}} active{{end}}"><span class="nav-key">A</span><span>Accounts</span></a>
-        <a href="/budgets" class="nav-link{{if hasPrefix .CurrentPath "/budgets"}} active{{end}}"><span class="nav-key">B</span><span>Budgets</span></a>
-        <a href="/investments" class="nav-link{{if hasPrefix .CurrentPath "/investments"}} active{{end}}"><span class="nav-key">I</span><span>Investments</span></a>
-        <a href="/loans" class="nav-link{{if hasPrefix .CurrentPath "/loans"}} active{{end}}"><span class="nav-key">L</span><span>Loans</span></a>
-        <a href="/insurance" class="nav-link{{if hasPrefix .CurrentPath "/insurance"}} active{{end}}"><span class="nav-key">P</span><span>Insurance</span></a>
-        <a href="/networth" class="nav-link{{if hasPrefix .CurrentPath "/networth"}} active{{end}}"><span class="nav-key">N</span><span>Net Worth</span></a>
+        <a href="/transactions" class="nav-link{{if hasPrefix .CurrentPath "/transactions"}} active{{end}}" title="Transactions">
+            <svg viewBox="0 0 24 24"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="16" y2="18"/></svg>
+            <span>Transactions</span>
+        </a>
+        <a href="/accounts" class="nav-link{{if hasPrefix .CurrentPath "/accounts"}} active{{end}}" title="Accounts">
+            <svg viewBox="0 0 24 24"><rect x="3" y="7" width="4" height="14" rx="1"/><rect x="10" y="5" width="4" height="16" rx="1"/><rect x="17" y="3" width="4" height="18" rx="1"/></svg>
+            <span>Accounts</span>
+        </a>
+        <a href="/budgets" class="nav-link{{if hasPrefix .CurrentPath "/budgets"}} active{{end}}" title="Budgets">
+            <svg viewBox="0 0 24 24"><rect x="4" y="14" width="4" height="6" rx="1"/><rect x="10" y="10" width="4" height="10" rx="1"/><rect x="16" y="5" width="4" height="15" rx="1"/></svg>
+            <span>Budgets</span>
+        </a>
+        <a href="/investments" class="nav-link{{if hasPrefix .CurrentPath "/investments"}} active{{end}}" title="Investments">
+            <svg viewBox="0 0 24 24"><path d="M12 2v20M2 12h20"/><circle cx="12" cy="12" r="9"/></svg>
+            <span>Investments</span>
+        </a>
+        <a href="/loans" class="nav-link{{if hasPrefix .CurrentPath "/loans"}} active{{end}}" title="Loans">
+            <svg viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>
+            <span>Loans</span>
+        </a>
+        <a href="/insurance" class="nav-link{{if hasPrefix .CurrentPath "/insurance"}} active{{end}}" title="Insurance">
+            <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+            <span>Insurance</span>
+        </a>
 
         <hr class="nav-divider">
 
-        <a href="/reports" class="nav-link{{if hasPrefix .CurrentPath "/reports"}} active{{end}}"><span class="nav-key">R</span><span>Reports</span></a>
-        <a href="/import" class="nav-link{{if hasPrefix .CurrentPath "/import"}} active{{end}}"><span class="nav-key">M</span><span>Import</span></a>
+        <a href="/reports" class="nav-link{{if hasPrefix .CurrentPath "/reports"}} active{{end}}" title="Reports">
+            <svg viewBox="0 0 24 24"><path d="M4 20h16"/><path d="M4 20V4"/><path d="M8 16V8"/><path d="M12 16v-4"/><path d="M16 16V6"/><path d="M20 16V2"/></svg>
+            <span>Reports</span>
+        </a>
+        <a href="/import" class="nav-link{{if hasPrefix .CurrentPath "/import"}} active{{end}}" title="Import">
+            <svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            <span>Import</span>
+        </a>
 
         <hr class="nav-divider">
 
-        <a href="/settings" class="nav-link{{if hasPrefix .CurrentPath "/settings"}} active{{end}}"><span class="nav-key">S</span><span>Settings</span></a>
-        <a href="/logout" class="nav-link nav-logout"><span class="nav-key">Q</span><span>Logout</span></a>
+        <a href="/settings" class="nav-link{{if hasPrefix .CurrentPath "/settings"}} active{{end}}" title="Settings">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+            <span>Settings</span>
+        </a>
+        <a href="/logout" class="nav-link nav-logout" title="Logout">
+            <svg viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+            <span>Logout</span>
+        </a>
     </div>
 </nav>
 {{end}}


### PR DESCRIPTION
Replaced Graphite+Lime with a warm minimal aesthetic inspired by Apple and Notion. Terracotta accent (#c25a3e), warm neutrals, compact 52px sidebar with inline SVG icons, typography-driven hierarchy, borders over shadows, full dark mode. Includes: CSS rewrite with design tokens, dashboard with hero number + KPI strip + SVG chart + CSS heatmap, 19 page templates updated with consistent components, responsive bottom nav at <768px. Chart.js scoped to report pages only. Verification: go test passes, go build succeeds.