### PR TITLE
fix: Dockerfile for SolidJS embed + single-service compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,27 @@
-# Stage 1: Build Go binary
-FROM golang:1.26-alpine AS builder
+# Stage 1: Build SolidJS frontend
+FROM node:22-alpine AS frontend-builder
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/bun.lock ./
+RUN npm install
+COPY frontend/ ./
+RUN npm run build
+
+# Stage 2: Build Go binary with embedded frontend
+FROM golang:1.26-alpine AS go-builder
 WORKDIR /app
 RUN apk add --no-cache git ca-certificates
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /ledgerify ./cmd/server
 
-# Stage 2: Minimal production image
+# Stage 3: Minimal runtime
 FROM alpine:3.21
 WORKDIR /app
 RUN apk add --no-cache ca-certificates tzdata
-COPY --from=builder /ledgerify /app/ledgerify
-COPY --from=builder /app/web/templates /app/web/templates
+COPY --from=go-builder /ledgerify /app/ledgerify
 EXPOSE 8080
 ENV PORT=8080
-ENV GIN_MODE=release
 USER nobody
 CMD ["/app/ledgerify"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,27 +3,15 @@ services:
     image: ghcr.io/kts-o7/ledgerify-web:latest
     restart: unless-stopped
     ports:
-      - "127.0.0.1:3000:3000"
-    environment:
-      DATABASE_URL: ${DATABASE_URL}
-      AUTH_SECRET: ${AUTH_SECRET}
-      AUTH_URL: ${AUTH_URL}
-      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL}
-      CRON_SECRET: ${CRON_SECRET}
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  go-api:
-    image: ghcr.io/kts-o7/ledgerify-web-go:latest
-    restart: unless-stopped
-    ports:
       - "127.0.0.1:8080:8080"
     environment:
       DATABASE_URL: ${DATABASE_URL}
       JWT_SECRET: ${AUTH_SECRET}
       FRONTEND_URL: ${NEXT_PUBLIC_APP_URL}
       PORT: "8080"
+      LLM_API_URL: ${LLM_API_URL}
+      LLM_API_KEY: ${LLM_API_KEY}
+      LLM_MODEL: ${LLM_MODEL}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Changes

**Dockerfile** (was broken after SolidJS rewrite):
- Added frontend build stage (Node 22 + npm install + vite build)
- Copies built frontend/dist into Go build context for go:embed
- Removed stale web/templates copy (HTMX stack removed in PR #46)
- Removed GIN_MODE=release (now using chi router)

**docker-compose.prod.yml**:
- Removed separate go-api service (now unified in single binary)
- Single app service on :8080 serving both API + embedded SolidJS frontend
- Added LLM env vars for AI features

## Verified on VPS
- Built and deployed locally, health check OK
- Frontend serves at https://money.shenthar.me